### PR TITLE
fix: remove userId query parameter from subscription status API calls

### DIFF
--- a/hooks/use-subscription.ts
+++ b/hooks/use-subscription.ts
@@ -63,7 +63,7 @@ export function useSubscription() {
       }
 
       try {
-        const response = await fetch(`/api/subscription/status?userId=${user.id}`)
+        const response = await fetch(`/api/subscription/status`)
 
         if (response.ok) {
           const data = await response.json()
@@ -131,7 +131,7 @@ export function useSubscription() {
 
       setLoading(true)
       try {
-        const response = await fetch(`/api/subscription/status?userId=${user.id}`)
+        const response = await fetch(`/api/subscription/status`)
         if (response.ok) {
           const data = await response.json()
 


### PR DESCRIPTION
CRITICAL FIX for 401 Unauthorized errors

Problem:
- Frontend was sending ?userId=${user.id} as query parameter
- Backend API was updated to use session authentication (more secure)
- This mismatch caused 401 Unauthorized errors

Changes:
- hooks/use-subscription.ts (line 66): Removed ?userId=${user.id}
- hooks/use-subscription.ts (line 134): Removed ?userId=${user.id} from refresh()

Impact:
✅ Fixes 401 errors on /api/subscription/status
✅ Fixes payment checkout flow (was failing with Unauthorized) ✅ Subscription data now loads correctly
✅ Premium features now accessible

Security Improvement:
- Query parameters can leak in logs and browser history
- Session-based auth is more secure and follows best practices
- Middleware refreshes session automatically

Testing:
- Subscription status should load without 401 errors
- Payment checkout should initialize successfully
- User should see correct subscription tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)