### PR TITLE
fix: update Gemini API model to gemini-1.5-flash-latest

### DIFF
--- a/app/api/analyze-pdf/route.ts
+++ b/app/api/analyze-pdf/route.ts
@@ -277,7 +277,7 @@ export async function POST(request: Request) {
 
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
     const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash",
+      model: "gemini-1.5-flash-latest",
       generationConfig: {
         temperature: 0.05,
         topK: 1,


### PR DESCRIPTION
Fixed 404 error when analyzing PDF files. The model name "gemini-1.5-flash" is no longer supported by Google Generative AI API v1beta. Updated to use "gemini-1.5-flash-latest" which is the current stable version.

Error before fix:
[GoogleGenerativeAI Error]: Error fetching from
https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent: [404 Not Found] models/gemini-1.5-flash is not found for API version v1beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)