### PR TITLE
feat: Apply landing page dark theme to all application pages

### DIFF
--- a/app/uygulama/ayarlar/page.tsx
+++ b/app/uygulama/ayarlar/page.tsx
@@ -751,48 +751,48 @@ export default function AyarlarPage() {
       </Card>
 
       {/* Modern Tabs */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="profile"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <User className="h-4 w-4" />
                 <span className="font-medium">Profil</span>
               </TabsTrigger>
               <TabsTrigger
                 value="subscription"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Crown className="h-4 w-4" />
                 <span className="font-medium">Abonelik</span>
               </TabsTrigger>
               <TabsTrigger
                 value="invoices"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <FileText className="h-4 w-4" />
                 <span className="font-medium">Faturalar</span>
               </TabsTrigger>
               <TabsTrigger
                 value="financial"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <DollarSign className="h-4 w-4" />
                 <span className="font-medium">Finansal</span>
               </TabsTrigger>
               <TabsTrigger
                 value="security"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Shield className="h-4 w-4" />
                 <span className="font-medium">Güvenlik</span>
               </TabsTrigger>
               <TabsTrigger
                 value="preferences"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Settings className="h-4 w-4" />
                 <span className="font-medium">Tercihler</span>
@@ -803,13 +803,13 @@ export default function AyarlarPage() {
           <div className="p-6">
             <TabsContent value="profile">
               <div className="space-y-6">
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <User className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Kişisel Bilgiler
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">Profil bilgilerinizi güncelleyin</CardDescription>
+                    <CardDescription className="dark:text-white/60">Profil bilgilerinizi güncelleyin</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-6">
                     {/* Profil Fotoğrafı */}
@@ -820,7 +820,7 @@ export default function AyarlarPage() {
                       </Avatar>
                       <div className="space-y-2">
                         <Label htmlFor="avatar" className="cursor-pointer">
-                          <div className="flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent rounded-md transition-colors">
+                          <div className="flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent rounded-md transition-colors">
                             {isUploadingAvatar ? (
                               <>
                                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -842,7 +842,7 @@ export default function AyarlarPage() {
                           className="hidden"
                           disabled={isUploadingAvatar}
                         />
-                        <p className="text-xs text-muted-foreground dark:text-gray-400">
+                        <p className="text-xs text-muted-foreground dark:text-white/60">
                           JPG, PNG, GIF veya WebP. Maksimum 10MB.
                           <br />
                           Seçilen fotoğraf otomatik olarak optimize edilip yüklenecek.
@@ -860,7 +860,7 @@ export default function AyarlarPage() {
                           id="first_name"
                           value={profileData.first_name || ""}
                           onChange={handleInputChange}
-                          className="custom-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="custom-input dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                       </div>
                       <div className="space-y-2">
@@ -871,7 +871,7 @@ export default function AyarlarPage() {
                           id="last_name"
                           value={profileData.last_name || ""}
                           onChange={handleInputChange}
-                          className="custom-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="custom-input dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                       </div>
                       <div className="space-y-2">
@@ -879,13 +879,13 @@ export default function AyarlarPage() {
                           E-posta
                         </Label>
                         <div className="relative">
-                          <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-gray-500" />
+                          <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-white/60" />
                           <Input
                             id="email"
                             type="email"
                             value={profileData.email || ""}
                             onChange={handleInputChange}
-                            className="pl-10 custom-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="pl-10 custom-input dark:bg-black/10 dark:border-white/10 dark:text-white"
                             disabled
                           />
                         </div>
@@ -895,12 +895,12 @@ export default function AyarlarPage() {
                           Telefon
                         </Label>
                         <div className="relative">
-                          <Phone className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-gray-500" />
+                          <Phone className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-white/60" />
                           <Input
                             id="phone"
                             value={profileData.phone || ""}
                             onChange={handleInputChange}
-                            className="pl-10 custom-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="pl-10 custom-input dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
                         </div>
                       </div>
@@ -911,12 +911,12 @@ export default function AyarlarPage() {
                         Adres
                       </Label>
                       <div className="relative">
-                        <MapPin className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-gray-500" />
+                        <MapPin className="absolute left-3 top-3 h-4 w-4 text-gray-400 dark:text-white/60" />
                         <Textarea
                           id="address"
                           value={profileData.address || ""}
                           onChange={(e) => setProfileData((prev) => ({ ...prev, address: e.target.value }))}
-                          className="pl-10 custom-input min-h-[80px] dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="pl-10 custom-input min-h-[80px] dark:bg-black/10 dark:border-white/10 dark:text-white"
                           placeholder="Tam adresinizi girin..."
                         />
                       </div>
@@ -929,13 +929,13 @@ export default function AyarlarPage() {
             <TabsContent value="subscription">
               <div className="space-y-6">
                 {/* Mevcut Plan */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Crown className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Mevcut Plan
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Abonelik durumunuz ve plan bilgileriniz
                     </CardDescription>
                   </CardHeader>
@@ -1092,21 +1092,21 @@ export default function AyarlarPage() {
                 </Card>
 
                 {/* Faturalama */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <FileText className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Faturalama
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Ödeme geçmişinizi ve faturalarınızı görüntüleyin
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-gray-700 dark:bg-gray-800/50">
+                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-white/10 dark:bg-black/10/50">
                       <div>
                         <p className="font-medium dark:text-white mb-1">Fatura Geçmişi</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-gray-500 dark:text-white/60">
                           Tüm ödeme işlemlerinizi ve faturalarınızı görüntüleyin
                         </p>
                       </div>
@@ -1148,10 +1148,10 @@ export default function AyarlarPage() {
                     </DialogHeader>
                     <div className="py-4">
                       <div className="space-y-3">
-                        <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                        <div className="p-4 bg-gray-50 dark:bg-black/10 rounded-lg">
                           <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">Mevcut Abonelik:</p>
                           <div className="flex items-center justify-between">
-                            <span className="text-base text-gray-700 dark:text-gray-300">
+                            <span className="text-base text-gray-700 dark:text-white/70">
                               {subscription?.plan_id === "premium-yearly" ? "Yıllık Premium" : "Aylık Premium"}
                             </span>
                             <Badge variant="outline">
@@ -1180,7 +1180,7 @@ export default function AyarlarPage() {
                       <Button
                         variant="outline"
                         onClick={() => setShowCancelDialog(false)}
-                        className="border-gray-300 dark:border-gray-700"
+                        className="border-gray-300 dark:border-white/10"
                         disabled={isCancelling}
                       >
                         Vazgeç
@@ -1210,13 +1210,13 @@ export default function AyarlarPage() {
             </TabsContent>
 
             <TabsContent value="financial">
-              <Card className="dark:bg-gray-900 dark:border-gray-800">
+              <Card className="dark:bg-black/20 dark:border-white/10">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 dark:text-white">
                     <DollarSign className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                     Finansal Bilgiler
                   </CardTitle>
-                  <CardDescription className="dark:text-gray-400">
+                  <CardDescription className="dark:text-white/60">
                     Risk analizi ve finansal planlama için bilgilerinizi girin.
                   </CardDescription>
                 </CardHeader>
@@ -1224,7 +1224,7 @@ export default function AyarlarPage() {
                   {loadingFinancialProfile ? (
                     <div className="flex justify-center items-center p-8">
                       <Loader2 className="h-8 w-8 animate-spin text-emerald-600 dark:text-emerald-400" />
-                      <p className="ml-2 dark:text-gray-300">Finansal bilgiler yükleniyor...</p>
+                      <p className="ml-2 dark:text-white/70">Finansal bilgiler yükleniyor...</p>
                     </div>
                   ) : (
                     <>
@@ -1239,9 +1239,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 25000"
                             value={financialProfileData.monthly_income ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Vergi sonrası aylık geliriniz
                           </p>
                         </div>
@@ -1255,9 +1255,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 18000"
                             value={financialProfileData.monthly_expenses ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Kira, market, faturalar dahil tüm giderler
                           </p>
                         </div>
@@ -1271,9 +1271,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 50000"
                             value={financialProfileData.emergency_fund ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Beklenmedik durumlar için ayrılan para
                           </p>
                         </div>
@@ -1287,9 +1287,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 75000"
                             value={financialProfileData.investment_portfolio ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Hisse, fon, altın vb. yatırımlar
                           </p>
                         </div>
@@ -1303,9 +1303,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 800000"
                             value={financialProfileData.real_estate_value ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Sahip olduğunuz ev/arsa değeri
                           </p>
                         </div>
@@ -1319,9 +1319,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 150000"
                             value={financialProfileData.vehicle_value ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Sahip olduğunuz araçların piyasa değeri
                           </p>
                         </div>
@@ -1335,9 +1335,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 12000"
                             value={financialProfileData.credit_card_debt ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Toplam kredi kartı borcunuz
                           </p>
                         </div>
@@ -1351,9 +1351,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 2500"
                             value={financialProfileData.other_monthly_obligations ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Nafaka, öğrenim kredisi vb.
                           </p>
                         </div>
@@ -1367,9 +1367,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 36"
                             value={financialProfileData.employment_duration_months ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          <p className="text-xs text-muted-foreground dark:text-white/60">
                             Mevcut işyerindeki deneyim süresi
                           </p>
                         </div>
@@ -1383,9 +1383,9 @@ export default function AyarlarPage() {
                             placeholder="Örn: 2"
                             value={financialProfileData.dependents_count ?? ""}
                             onChange={handleFinancialInputChange}
-                            className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                            className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                           />
-                          <p className="text-xs text-muted-foreground dark:text-gray-400">Çocuk, yaşlı ebeveyn vb.</p>
+                          <p className="text-xs text-muted-foreground dark:text-white/60">Çocuk, yaşlı ebeveyn vb.</p>
                         </div>
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -1397,10 +1397,10 @@ export default function AyarlarPage() {
                             value={financialProfileData.employment_status || ""}
                             onValueChange={(value) => handleSelectChange("employment_status", value)}
                           >
-                            <SelectTrigger className="dark:bg-gray-800 dark:border-gray-700 dark:text-white">
+                            <SelectTrigger className="dark:bg-black/10 dark:border-white/10 dark:text-white">
                               <SelectValue placeholder="Seçiniz..." />
                             </SelectTrigger>
-                            <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
+                            <SelectContent className="dark:bg-black/10 dark:border-white/10">
                               <SelectItem value="tam_zamanli">Tam Zamanlı Çalışan</SelectItem>
                               <SelectItem value="yari_zamanli">Yarı Zamanlı Çalışan</SelectItem>
                               <SelectItem value="serbest_calisan">Serbest Çalışan (Freelancer)</SelectItem>
@@ -1420,10 +1420,10 @@ export default function AyarlarPage() {
                             value={financialProfileData.housing_status || ""}
                             onValueChange={(value) => handleSelectChange("housing_status", value)}
                           >
-                            <SelectTrigger className="dark:bg-gray-800 dark:border-gray-700 dark:text-white">
+                            <SelectTrigger className="dark:bg-black/10 dark:border-white/10 dark:text-white">
                               <SelectValue placeholder="Seçiniz..." />
                             </SelectTrigger>
-                            <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
+                            <SelectContent className="dark:bg-black/10 dark:border-white/10">
                               <SelectItem value="kira">Kiracı</SelectItem>
                               <SelectItem value="ev_sahibi_kredili">Ev Sahibi (Kredili)</SelectItem>
                               <SelectItem value="ev_sahibi_kredisiz">Ev Sahibi (Kredisiz)</SelectItem>
@@ -1442,7 +1442,7 @@ export default function AyarlarPage() {
                           placeholder="Örn: Kredi kartı borcu, öğrenim kredisi"
                           value={financialProfileData.other_debt_obligations || ""}
                           onChange={handleFinancialInputChange}
-                          className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                       </div>
                       <div className="space-y-2">
@@ -1454,7 +1454,7 @@ export default function AyarlarPage() {
                           placeholder="Örn: Ev almak, araba almak, emeklilik"
                           value={financialProfileData.savings_goals || ""}
                           onChange={handleFinancialInputChange}
-                          className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                       </div>
                       <div className="space-y-2">
@@ -1465,10 +1465,10 @@ export default function AyarlarPage() {
                           value={financialProfileData.risk_tolerance || ""}
                           onValueChange={(value) => handleSelectChange("risk_tolerance", value)}
                         >
-                          <SelectTrigger className="dark:bg-gray-800 dark:border-gray-700 dark:text-white">
+                          <SelectTrigger className="dark:bg-black/10 dark:border-white/10 dark:text-white">
                             <SelectValue placeholder="Seçiniz..." />
                           </SelectTrigger>
-                          <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
+                          <SelectContent className="dark:bg-black/10 dark:border-white/10">
                             <SelectItem value="dusuk">Düşük</SelectItem>
                             <SelectItem value="orta">Orta</SelectItem>
                             <SelectItem value="yuksek">Yüksek</SelectItem>
@@ -1478,7 +1478,7 @@ export default function AyarlarPage() {
                       <div className="pt-4">
                         <Button
                           variant="outline"
-                          className="border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent"
+                          className="border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent"
                           onClick={handleSaveFinancialProfile}
                           disabled={isSavingFinancial}
                         >
@@ -1506,13 +1506,13 @@ export default function AyarlarPage() {
             <TabsContent value="security">
               <div className="space-y-6">
                 {/* Şifre Değiştirme */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Key className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Şifre Değiştir
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Hesabınızın güvenliği için güçlü bir şifre kullanın
                     </CardDescription>
                   </CardHeader>
@@ -1528,7 +1528,7 @@ export default function AyarlarPage() {
                           value={currentPassword}
                           onChange={(e) => setCurrentPassword(e.target.value)}
                           placeholder="Mevcut şifrenizi girin"
-                          className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                         <Button
                           type="button"
@@ -1552,7 +1552,7 @@ export default function AyarlarPage() {
                           value={newPassword}
                           onChange={(e) => setNewPassword(e.target.value)}
                           placeholder="Yeni şifrenizi girin"
-                          className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                         <Button
                           type="button"
@@ -1576,7 +1576,7 @@ export default function AyarlarPage() {
                           value={confirmPassword}
                           onChange={(e) => setConfirmPassword(e.target.value)}
                           placeholder="Yeni şifrenizi tekrar girin"
-                          className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                          className="dark:bg-black/10 dark:border-white/10 dark:text-white"
                         />
                         <Button
                           type="button"
@@ -1623,13 +1623,13 @@ export default function AyarlarPage() {
                 </Card>
 
                 {/* Oturum Geçmişi */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Monitor className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Aktif Oturumlar
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Hesabınıza bağlı cihazları görüntüleyin ve yönetin
                     </CardDescription>
                   </CardHeader>
@@ -1640,27 +1640,27 @@ export default function AyarlarPage() {
                       </div>
                     ) : sessions.length === 0 ? (
                       <div className="text-center py-8">
-                        <p className="text-gray-500 dark:text-gray-400">Aktif oturum bulunamadı</p>
+                        <p className="text-gray-500 dark:text-white/60">Aktif oturum bulunamadı</p>
                       </div>
                     ) : (
                       <div className="space-y-4">
                         {sessions.map((session) => (
                           <div
                             key={session.id}
-                            className="flex items-center justify-between p-4 border rounded-lg dark:border-gray-700 dark:bg-gray-800/50"
+                            className="flex items-center justify-between p-4 border rounded-lg dark:border-white/10 dark:bg-black/10/50"
                           >
                             <div className="flex items-center gap-3">
-                              <Monitor className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+                              <Monitor className="h-5 w-5 text-gray-400 dark:text-white/60" />
                               <div>
                                 <p className="font-medium flex items-center gap-2 dark:text-white">
                                   {session.device}
                                   {session.is_current && <Badge variant="secondary">Mevcut</Badge>}
                                 </p>
-                                <p className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                                <p className="text-sm text-gray-500 dark:text-white/60 flex items-center gap-1">
                                   <Location className="h-3 w-3" />
                                   {session.location}
                                 </p>
-                                <p className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                                <p className="text-sm text-gray-500 dark:text-white/60 flex items-center gap-1">
                                   <Clock className="h-3 w-3" />
                                   {session.lastActive}
                                 </p>
@@ -1669,7 +1669,7 @@ export default function AyarlarPage() {
                             {!session.is_current && (
                               <Button
                                 variant="outline"
-                                className="border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent"
+                                className="border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent"
                                 size="sm"
                                 onClick={() => handleRevokeSession(session.id)}
                               >
@@ -1685,13 +1685,13 @@ export default function AyarlarPage() {
                 </Card>
 
                 {/* Hesap Silme */}
-                <Card className="border-red-200 dark:border-red-700/50 dark:bg-gray-900">
+                <Card className="border-red-200 dark:border-red-700/50 dark:bg-black/20">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-red-600 dark:text-red-400">
                       <AlertTriangle className="h-5 w-5" />
                       Tehlikeli Bölge
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Bu işlemler geri alınamaz. Dikkatli olun.
                     </CardDescription>
                   </CardHeader>
@@ -1716,19 +1716,19 @@ export default function AyarlarPage() {
             <TabsContent value="preferences">
               <div className="space-y-6">
                 {/* Görünüm Ayarları */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Monitor className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Görünüm Ayarları
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">Uygulama görünümünü özelleştirin</CardDescription>
+                    <CardDescription className="dark:text-white/60">Uygulama görünümünü özelleştirin</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium dark:text-white">Koyu Tema</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-gray-500 dark:text-white/60">
                           Gözlerinizi yormaması için koyu tema kullanın
                         </p>
                       </div>
@@ -1738,7 +1738,7 @@ export default function AyarlarPage() {
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium dark:text-white">Kompakt Görünüm</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">Daha fazla bilgiyi aynı alanda görün</p>
+                        <p className="text-sm text-gray-500 dark:text-white/60">Daha fazla bilgiyi aynı alanda görün</p>
                       </div>
                       <Switch checked={compactView} onCheckedChange={handleCompactViewToggle} />
                     </div>
@@ -1746,7 +1746,7 @@ export default function AyarlarPage() {
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium dark:text-white">Animasyonlar</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">Geçiş animasyonlarını etkinleştirin</p>
+                        <p className="text-sm text-gray-500 dark:text-white/60">Geçiş animasyonlarını etkinleştirin</p>
                       </div>
                       <Switch checked={animationsEnabled} onCheckedChange={handleAnimationsToggle} />
                     </div>
@@ -1754,21 +1754,21 @@ export default function AyarlarPage() {
                 </Card>
 
                 {/* Bildirim Ayarları */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Bell className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Bildirim Ayarları
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Detaylı bildirim tercihlerinizi yönetin
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-gray-700 dark:bg-gray-800/50">
+                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-white/10 dark:bg-black/10/50">
                       <div>
                         <p className="font-medium dark:text-white">Gelişmiş Bildirim Ayarları</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-gray-500 dark:text-white/60">
                           E-posta hatırlatıcıları, zaman ayarları ve test fonksiyonları
                         </p>
                       </div>
@@ -1781,24 +1781,24 @@ export default function AyarlarPage() {
                 </Card>
 
                 {/* Veri Yönetimi */}
-                <Card className="dark:bg-gray-900 dark:border-gray-800">
+                <Card className="dark:bg-black/20 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 dark:text-white">
                       <Download className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                       Veri Yönetimi
                     </CardTitle>
-                    <CardDescription className="dark:text-gray-400">
+                    <CardDescription className="dark:text-white/60">
                       Verilerinizi yönetin ve dışa aktarın
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-gray-700 dark:bg-gray-800/50">
+                    <div className="flex items-center justify-between p-4 border rounded-lg dark:border-white/10 dark:bg-black/10/50">
                       <div className="flex-1">
                         <p className="font-medium dark:text-white flex items-center gap-2">
                           <Download className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                           Verilerimi Dışa Aktar
                         </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                        <p className="text-sm text-gray-500 dark:text-white/60 mt-1">
                           Tüm kredilerinizi, kredi kartlarınızı, hesaplarınızı, ödeme geçmişinizi, risk
                           analizlerinizi ve profil bilgilerinizi JSON formatında yedekleyin
                         </p>

--- a/app/uygulama/bildirimler/page.tsx
+++ b/app/uygulama/bildirimler/page.tsx
@@ -274,10 +274,10 @@ export default function BildirimlerPage() {
   if (loading) {
     return (
       <div className="space-y-6 animate-pulse">
-        <div className="h-32 bg-gray-200 dark:bg-gray-800 rounded-2xl"></div>
+        <div className="h-32 bg-gray-200 dark:bg-black/10 rounded-2xl"></div>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           {[...Array(4)].map((_, i) => (
-            <div key={i} className="h-32 bg-gray-200 dark:bg-gray-800 rounded-xl"></div>
+            <div key={i} className="h-32 bg-gray-200 dark:bg-black/10 rounded-xl"></div>
           ))}
         </div>
       </div>
@@ -354,9 +354,9 @@ export default function BildirimlerPage() {
       </div>
 
       {/* Modern Table */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         {/* Table Header */}
-        <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50 p-6">
+        <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50 p-6">
           <div className="flex items-center justify-between flex-wrap gap-4">
             <CardTitle className="text-xl font-bold text-gray-800 dark:text-white">Bildirim Listesi</CardTitle>
 
@@ -364,7 +364,7 @@ export default function BildirimlerPage() {
               <Button
                 variant="outline"
                 onClick={() => loadNotifications(true)}
-                className="gap-2 bg-transparent dark:bg-transparent dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                className="gap-2 bg-transparent dark:bg-transparent dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
               >
                 <RefreshCw className="h-4 w-4" />
                 Yenile
@@ -382,12 +382,12 @@ export default function BildirimlerPage() {
           {/* Search and Filters */}
           <div className="flex items-center gap-4 flex-wrap mt-4">
             <div className="relative flex-1 min-w-64">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 h-4 w-4 pointer-events-none" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-white/60 h-4 w-4 pointer-events-none" />
               <Input
                 placeholder="Bildirim ara..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 dark:text-white focus-visible:border-emerald-500 focus-visible:shadow-[0_0_0_0.5px_rgb(16,185,129)] transition-all duration-200"
+                className="pl-10 bg-white dark:bg-black/10 border border-gray-200 dark:border-white/10 dark:text-white focus-visible:border-emerald-500 focus-visible:shadow-[0_0_0_0.5px_rgb(16,185,129)] transition-all duration-200"
                 autoComplete="off"
                 spellCheck="false"
               />
@@ -408,15 +408,15 @@ export default function BildirimlerPage() {
         <div className="p-6">
           {paginatedNotifications.length === 0 ? (
             <div className="text-center py-10">
-              <div className="w-24 h-24 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Bell className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+              <div className="w-24 h-24 bg-gray-100 dark:bg-black/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <Bell className="h-12 w-12 text-gray-400 dark:text-white/60" />
               </div>
-              <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-200 mb-2">
+              <h3 className="text-xl font-semibold text-gray-700 dark:text-white/70 mb-2">
                 {searchTerm || showUnreadOnly
                   ? "Filtre kriterlerine uygun bildirim bulunamadı"
                   : "Henüz bildiriminiz yok"}
               </h3>
-              <p className="text-gray-500 dark:text-gray-400 mb-6">
+              <p className="text-gray-500 dark:text-white/60 mb-6">
                 {searchTerm || showUnreadOnly
                   ? "Farklı filtreler deneyebilir veya arama teriminizi değiştirebilirsiniz."
                   : "Yeni bildirimler otomatik olarak oluşturulacak ve burada görünecek."}
@@ -427,13 +427,13 @@ export default function BildirimlerPage() {
               <div className="overflow-x-auto">
                 <Table>
                   <TableHeader>
-                    <TableRow className="bg-white dark:bg-gray-900 border-b dark:border-gray-800">
-                      <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Tip</TableHead>
-                      <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Başlık</TableHead>
-                      <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Mesaj</TableHead>
-                      <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Zaman</TableHead>
-                      <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Durum</TableHead>
-                      <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-gray-300">
+                    <TableRow className="bg-white dark:bg-black/20 border-b dark:border-white/10">
+                      <TableHead className="font-semibold text-gray-700 dark:text-white/70">Tip</TableHead>
+                      <TableHead className="font-semibold text-gray-700 dark:text-white/70">Başlık</TableHead>
+                      <TableHead className="font-semibold text-gray-700 dark:text-white/70">Mesaj</TableHead>
+                      <TableHead className="font-semibold text-gray-700 dark:text-white/70">Zaman</TableHead>
+                      <TableHead className="font-semibold text-gray-700 dark:text-white/70">Durum</TableHead>
+                      <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-white/70">
                         İşlemler
                       </TableHead>
                     </TableRow>
@@ -448,8 +448,8 @@ export default function BildirimlerPage() {
                       return (
                         <TableRow
                           key={notification.id}
-                          className={`transition-colors duration-150 ease-in-out border-b dark:border-gray-800 ${
-                            index % 2 === 0 ? "bg-white dark:bg-gray-900" : "bg-gray-50/50 dark:bg-gray-800/50"
+                          className={`transition-colors duration-150 ease-in-out border-b dark:border-white/10 ${
+                            index % 2 === 0 ? "bg-white dark:bg-black/20" : "bg-gray-50/50 dark:bg-black/10/50"
                           } ${!notification.is_read ? "bg-blue-50/30 dark:bg-blue-900/20" : ""}`}
                         >
                           <TableCell>
@@ -467,13 +467,13 @@ export default function BildirimlerPage() {
                             </div>
                           </TableCell>
 
-                          <TableCell className="text-gray-600 dark:text-gray-300 max-w-64">
+                          <TableCell className="text-gray-600 dark:text-white/70 max-w-64">
                             <div className="truncate" title={notification.message}>
                               {notification.message}
                             </div>
                           </TableCell>
 
-                          <TableCell className="text-gray-500 dark:text-gray-400">
+                          <TableCell className="text-gray-500 dark:text-white/60">
                             <div className="flex items-center gap-1">
                               <Clock className="h-3 w-3" />
                               <span className="text-sm">
@@ -491,7 +491,7 @@ export default function BildirimlerPage() {
                                 <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></div>
                               )}
                               <Badge
-                                className={`${!notification.is_read ? "bg-emerald-500 text-white" : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"} text-xs px-2 py-1`}
+                                className={`${!notification.is_read ? "bg-emerald-500 text-white" : "bg-gray-100 dark:bg-black/10 text-gray-600 dark:text-white/70"} text-xs px-2 py-1`}
                               >
                                 {notification.is_read ? "Okundu" : "Yeni"}
                               </Badge>
@@ -510,11 +510,11 @@ export default function BildirimlerPage() {
                                   <span className="sr-only">Actions</span>
                                 </Button>
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" className="dark:bg-gray-800 dark:border-gray-700">
+                              <DropdownMenuContent align="end" className="dark:bg-black/10 dark:border-white/10">
                                 {!notification.is_read && (
                                   <DropdownMenuItem
                                     onClick={() => handleMarkAsRead(notification.id)}
-                                    className="dark:text-gray-200 dark:hover:bg-gray-700"
+                                    className="dark:text-white/70 dark:hover:bg-black/10"
                                   >
                                     <Check className="mr-2 h-4 w-4" />
                                     Okundu İşaretle
@@ -522,13 +522,13 @@ export default function BildirimlerPage() {
                                 )}
                                 <DropdownMenuItem
                                   onClick={() => handleViewNotification(notification)}
-                                  className="dark:text-gray-200 dark:hover:bg-gray-700"
+                                  className="dark:text-white/70 dark:hover:bg-black/10"
                                 >
                                   <Eye className="mr-2 h-4 w-4" />
                                   Detayları Gör
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
-                                  className="text-red-600 dark:text-red-400 dark:hover:bg-gray-700"
+                                  className="text-red-600 dark:text-red-400 dark:hover:bg-black/10"
                                   onClick={() => handleDelete(notification.id)}
                                 >
                                   <Trash2 className="mr-2 h-4 w-4" />
@@ -563,7 +563,7 @@ export default function BildirimlerPage() {
       </div>
 
       {/* Auto-refresh info */}
-      <Card className="border-0 shadow-lg bg-gradient-to-r from-emerald-50 to-blue-50 dark:from-emerald-900/20 dark:to-blue-900/20 dark:border dark:border-gray-800">
+      <Card className="border-0 shadow-lg bg-gradient-to-r from-emerald-50 to-blue-50 dark:from-emerald-900/20 dark:to-blue-900/20 dark:border dark:border-white/10">
         <CardContent className="p-6">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg">
@@ -571,7 +571,7 @@ export default function BildirimlerPage() {
             </div>
             <div>
               <h3 className="font-semibold text-gray-800 dark:text-white mb-1">Otomatik Bildirimler</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-300">
+              <p className="text-sm text-gray-600 dark:text-white/70">
                 Yaklaşan ödemeleriniz için otomatik olarak bildirimler oluşturulur ve header'da görüntülenir.
               </p>
             </div>

--- a/app/uygulama/faturalandirma/page.tsx
+++ b/app/uygulama/faturalandirma/page.tsx
@@ -160,14 +160,14 @@ export default function FaturalandirmaPage() {
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="p-4 border rounded-lg">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Ödeme Yöntemi</p>
+                  <p className="text-sm text-gray-500 dark:text-white/60 mb-1">Ödeme Yöntemi</p>
                   <div className="flex items-center gap-2">
                     <CreditCard className="h-4 w-4" />
                     <p className="font-medium">Kredi Kartı</p>
                   </div>
                 </div>
                 <div className="p-4 border rounded-lg">
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">Bitiş Tarihi</p>
+                  <p className="text-sm text-gray-500 dark:text-white/60 mb-1">Bitiş Tarihi</p>
                   <div className="flex items-center gap-2">
                     <Calendar className="h-4 w-4" />
                     <p className="font-medium">

--- a/app/uygulama/kredi-detay/[id]/page.tsx
+++ b/app/uygulama/kredi-detay/[id]/page.tsx
@@ -590,7 +590,7 @@ export default function KrediDetayPage() {
     return (
       <div className="flex flex-col gap-4 md:gap-6 items-center justify-center min-h-[calc(100vh-150px)]">
         <Loader2 className="h-12 w-12 animate-spin text-emerald-600" />
-        <p className="text-lg text-gray-600 dark:text-gray-400">Kredi detayları yükleniyor...</p>
+        <p className="text-lg text-gray-600 dark:text-white/60">Kredi detayları yükleniyor...</p>
       </div>
     )
   }
@@ -738,13 +738,13 @@ export default function KrediDetayPage() {
       </div>
 
       {/* Modern Tabs */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="bg-white dark:bg-black/10 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-700 bg-gray-100 dark:bg-gray-900">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-100 dark:bg-black/20">
             <TabsList className="grid grid-cols-5 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="genel"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <FileText className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Genel Bilgiler</span>
@@ -752,7 +752,7 @@ export default function KrediDetayPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="odeme-plani"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Calendar className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Ödeme Planı</span>
@@ -760,7 +760,7 @@ export default function KrediDetayPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="gecmis"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <History className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Ödeme Geçmişi</span>
@@ -768,7 +768,7 @@ export default function KrediDetayPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="grafikler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <BarChart3 className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Grafikler</span>
@@ -776,7 +776,7 @@ export default function KrediDetayPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="ayarlar"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Settings className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Ayarlar</span>
@@ -789,7 +789,7 @@ export default function KrediDetayPage() {
             {activeTab === "genel" && (
               <div className="space-y-6">
                 <div className="grid md:grid-cols-2 gap-6">
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <CreditCard className="h-5 w-5 text-teal-600" />
@@ -799,47 +799,47 @@ export default function KrediDetayPage() {
                     <CardContent className="space-y-4">
                       <div className="grid grid-cols-2 gap-4">
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Kredi Kodu</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Kredi Kodu</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">{krediDetay.credit_code}</p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Hesap No</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Hesap No</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">
                             {krediDetay.account_number || "N/A"}
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Başlangıç Tutarı</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Başlangıç Tutarı</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">
                             {formatCurrency(krediDetay.initial_amount)}
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Kredi Notu</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Kredi Notu</p>
                           <Badge className="bg-gradient-to-r from-emerald-600 to-teal-700 text-white border-transparent hover:from-emerald-700 hover:to-teal-800">
                             {krediDetay.credit_score || "N/A"}
                           </Badge>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Başlangıç Tarihi</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Başlangıç Tarihi</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">
                             {new Date(krediDetay.start_date).toLocaleDateString("tr-TR")}
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Bitiş Tarihi</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Bitiş Tarihi</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">
                             {new Date(krediDetay.end_date).toLocaleDateString("tr-TR")}
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Teminat</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Teminat</p>
                           <p className="font-medium text-gray-900 dark:text-gray-100">
                             {krediDetay.collateral || "N/A"}
                           </p>
                         </div>
                         <div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Sigorta</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Sigorta</p>
                           <Badge className="bg-gradient-to-r from-blue-600 to-indigo-700 text-white border-transparent hover:from-blue-700 hover:to-indigo-800 capitalize">
                             {krediDetay.insurance_status || "N/A"}
                           </Badge>
@@ -848,7 +848,7 @@ export default function KrediDetayPage() {
                     </CardContent>
                   </Card>
 
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <Building className="h-5 w-5 text-teal-600" />
@@ -866,7 +866,7 @@ export default function KrediDetayPage() {
                           <p className="font-semibold text-gray-900 dark:text-gray-100">
                             {krediDetay.banks?.name || "N/A"}
                           </p>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">{krediDetay.branch_name || "N/A"}</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">{krediDetay.branch_name || "N/A"}</p>
                         </div>
                       </div>
                     </CardContent>
@@ -941,7 +941,7 @@ export default function KrediDetayPage() {
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Ödeme Planı</h3>
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                    <p className="text-sm text-gray-600 dark:text-white/60">
                       Toplam {odemePlani.length} taksit • Sayfa {currentPage} / {totalPages}
                     </p>
                   </div>
@@ -978,7 +978,7 @@ export default function KrediDetayPage() {
                         return (
                           <div
                             key={taksit.id}
-                            className="flex items-center justify-between p-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
+                            className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
                           >
                             <div className="flex items-center gap-4">
                               <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shadow-lg">
@@ -991,10 +991,10 @@ export default function KrediDetayPage() {
                                     Taksit #{taksit.installment_number}
                                   </span>
                                 </div>
-                                <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                                <div className="text-sm text-gray-600 dark:text-white/60 mt-1">
                                   Vade: {new Date(taksit.due_date).toLocaleDateString("tr-TR")}
                                 </div>
-                                <div className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+                                <div className="text-xs text-gray-500 dark:text-white/60 mt-1">
                                   Ana Para: {formatCurrency(taksit.principal_amount)} • Faiz:{" "}
                                   {formatCurrency(taksit.interest_amount)}
                                 </div>
@@ -1006,7 +1006,7 @@ export default function KrediDetayPage() {
                                 <div className="font-bold text-gray-900 dark:text-gray-100 text-lg">
                                   {formatCurrency(taksit.total_payment)}
                                 </div>
-                                <div className="text-xs text-gray-500 dark:text-gray-500">
+                                <div className="text-xs text-gray-500 dark:text-white/60">
                                   Kalan: {formatCurrency(taksit.remaining_debt)}
                                 </div>
                               </div>
@@ -1112,7 +1112,7 @@ export default function KrediDetayPage() {
                     </div>
                   </>
                 ) : (
-                  <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+                  <div className="text-center py-12 text-gray-500 dark:text-white/60">
                     <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
                     <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Ödeme Planı Bulunamadı</h3>
                     <p className="text-sm">Bu kredi için ödeme planı bulunmuyor</p>
@@ -1127,7 +1127,7 @@ export default function KrediDetayPage() {
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Ödeme Geçmişi</h3>
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                    <p className="text-sm text-gray-600 dark:text-white/60">
                       Toplam {odemeGecmisi.length} ödeme • Sayfa {currentPageHistory} / {totalHistoryPages}
                     </p>
                   </div>
@@ -1144,7 +1144,7 @@ export default function KrediDetayPage() {
                       {currentHistoryItems.map((odeme, index) => (
                         <div
                           key={odeme.id}
-                          className="flex items-center justify-between p-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
+                          className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
                         >
                           <div className="flex items-center gap-4">
                             <div className="bg-gradient-to-br from-emerald-500 to-teal-600 p-3 rounded-full shadow-lg">
@@ -1157,7 +1157,7 @@ export default function KrediDetayPage() {
                                   Ödeme #{startIndexHistory + index + 1}
                                 </span>
                               </div>
-                              <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                              <div className="text-sm text-gray-600 dark:text-white/60 mt-1">
                                 {new Date(odeme.payment_date).toLocaleDateString("tr-TR", {
                                   weekday: "long",
                                   year: "numeric",
@@ -1165,7 +1165,7 @@ export default function KrediDetayPage() {
                                   day: "numeric",
                                 })}
                               </div>
-                              <div className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+                              <div className="text-xs text-gray-500 dark:text-white/60 mt-1">
                                 Kanal: {odeme.payment_channel || "Bilinmiyor"} • Referans:{" "}
                                 {odeme.transaction_id || "N/A"}
                               </div>
@@ -1175,7 +1175,7 @@ export default function KrediDetayPage() {
                           <div className="flex items-center gap-4">
                             <div className="text-right">
                               <div className="font-bold text-emerald-600 text-xl">{formatCurrency(odeme.amount)}</div>
-                              <div className="text-xs text-gray-500 dark:text-gray-500">
+                              <div className="text-xs text-gray-500 dark:text-white/60">
                                 {new Date(odeme.payment_date).toLocaleTimeString("tr-TR", {
                                   hour: "2-digit",
                                   minute: "2-digit",
@@ -1412,7 +1412,7 @@ export default function KrediDetayPage() {
                     </div>
                   </>
                 ) : (
-                  <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+                  <div className="text-center py-12 text-gray-500 dark:text-white/60">
                     <History className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
                     <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Ödeme Geçmişi Bulunamadı</h3>
                     <p className="text-sm">Bu kredi için henüz ödeme yapılmamış</p>
@@ -1425,13 +1425,13 @@ export default function KrediDetayPage() {
             {activeTab === "grafikler" && (
               <div className="space-y-6">
                 <div className="grid md:grid-cols-2 gap-6">
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <TrendingUp className="h-5 w-5 text-teal-600" />
                         Borç Azalış Grafiği
                       </CardTitle>
-                      <CardDescription className="dark:text-gray-400">
+                      <CardDescription className="dark:text-white/60">
                         Aylık borç azalışı ve ödenen tutar analizi
                       </CardDescription>
                     </CardHeader>
@@ -1487,13 +1487,13 @@ export default function KrediDetayPage() {
                     </CardContent>
                   </Card>
 
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <BarChart3 className="h-5 w-5 text-teal-600" />
                         Faiz/Ana Para Dağılımı
                       </CardTitle>
-                      <CardDescription className="dark:text-gray-400">
+                      <CardDescription className="dark:text-white/60">
                         Ödeme dağılımınızın detaylı analizi
                       </CardDescription>
                     </CardHeader>
@@ -1570,13 +1570,13 @@ export default function KrediDetayPage() {
 
                 {/* Additional Charts Row */}
                 <div className="grid md:grid-cols-2 gap-6">
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <Calendar className="h-5 w-5 text-teal-600" />
                         Aylık Ödeme Trendi
                       </CardTitle>
-                      <CardDescription className="dark:text-gray-400">Son 6 ayın ödeme performansı</CardDescription>
+                      <CardDescription className="dark:text-white/60">Son 6 ayın ödeme performansı</CardDescription>
                     </CardHeader>
                     <CardContent>
                       <ChartContainer
@@ -1622,13 +1622,13 @@ export default function KrediDetayPage() {
                     </CardContent>
                   </Card>
 
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
                         <Target className="h-5 w-5 text-teal-600" />
                         Ödeme İlerlemesi
                       </CardTitle>
-                      <CardDescription className="dark:text-gray-400">Kredi tamamlanma durumu</CardDescription>
+                      <CardDescription className="dark:text-white/60">Kredi tamamlanma durumu</CardDescription>
                     </CardHeader>
                     <CardContent className="flex flex-col items-center justify-center h-[250px]">
                       <div className="relative w-32 h-32 mb-4">
@@ -1662,7 +1662,7 @@ export default function KrediDetayPage() {
                         </div>
                       </div>
                       <div className="text-center">
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Tamamlanan Ödeme</p>
+                        <p className="text-sm text-gray-600 dark:text-white/60 mb-2">Tamamlanan Ödeme</p>
                         <p className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                           {(krediDetay?.total_installments || 0) - (krediDetay?.remaining_installments || 0)} /{" "}
                           {krediDetay?.total_installments || 0} Taksit
@@ -1678,10 +1678,10 @@ export default function KrediDetayPage() {
             {activeTab === "ayarlar" && (
               <div className="space-y-6">
                 <div className="grid md:grid-cols-2 gap-6">
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="text-gray-900 dark:text-gray-100">Bildirim Ayarları</CardTitle>
-                      <CardDescription className="dark:text-gray-400">
+                      <CardDescription className="dark:text-white/60">
                         Bu kredi için bildirim tercihleriniz
                       </CardDescription>
                     </CardHeader>
@@ -1689,7 +1689,7 @@ export default function KrediDetayPage() {
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-medium text-gray-900 dark:text-gray-100">Ödeme Hatırlatması</p>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                          <p className="text-sm text-gray-500 dark:text-white/60">
                             Ödeme tarihi yaklaştığında bildirim al
                           </p>
                         </div>
@@ -1698,7 +1698,7 @@ export default function KrediDetayPage() {
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-medium text-gray-900 dark:text-gray-100">Faiz Oranı Değişikliği</p>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                          <p className="text-sm text-gray-500 dark:text-white/60">
                             Faiz oranı değiştiğinde bildirim al
                           </p>
                         </div>
@@ -1707,17 +1707,17 @@ export default function KrediDetayPage() {
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-medium text-gray-900 dark:text-gray-100">Aylık Rapor</p>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">Aylık kredi raporu gönder</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60">Aylık kredi raporu gönder</p>
                         </div>
                         <Switch />
                       </div>
                     </CardContent>
                   </Card>
 
-                  <Card className="shadow-sm border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+                  <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
                       <CardTitle className="text-gray-900 dark:text-gray-100">Hızlı İşlemler</CardTitle>
-                      <CardDescription className="dark:text-gray-400">
+                      <CardDescription className="dark:text-white/60">
                         Bu kredi için yapabileceğiniz işlemler
                       </CardDescription>
                     </CardHeader>

--- a/app/uygulama/kredi-duzenle/[id]/page.tsx
+++ b/app/uygulama/kredi-duzenle/[id]/page.tsx
@@ -351,7 +351,7 @@ export default function KrediDuzenlePage() {
     return (
       <div className="flex flex-col gap-4 md:gap-6 items-center justify-center min-h-[calc(100vh-150px)]">
         <Loader2 className="h-12 w-12 animate-spin text-emerald-600 dark:text-emerald-400" />
-        <p className="text-lg text-gray-600 dark:text-gray-400">Kredi bilgileri yükleniyor...</p>
+        <p className="text-lg text-gray-600 dark:text-white/60">Kredi bilgileri yükleniyor...</p>
       </div>
     )
   }
@@ -444,13 +444,13 @@ export default function KrediDuzenlePage() {
       </div>
 
       {/* Modern Tabs - Kredi Detay Sayfasıyla Aynı Tasarım */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-100 dark:bg-gray-800">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-100 dark:bg-black/10">
             <TabsList className="grid grid-cols-2 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="credit-info"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <CreditCard className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Kredi Bilgileri</span>
@@ -458,7 +458,7 @@ export default function KrediDuzenlePage() {
               </TabsTrigger>
               <TabsTrigger
                 value="payment-plan"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <CalendarDays className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Ödeme Planı</span>
@@ -471,7 +471,7 @@ export default function KrediDuzenlePage() {
             {activeTab === "credit-info" && (
               <div className="space-y-6">
                 {/* Temel Kredi Bilgileri */}
-                <Card className="shadow-sm border-gray-200 dark:border-gray-800">
+                <Card className="shadow-sm border-gray-200 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                       Temel Kredi Bilgileri
@@ -600,7 +600,7 @@ export default function KrediDuzenlePage() {
                 </Card>
 
                 {/* Finansal Bilgiler */}
-                <Card className="shadow-sm border-gray-200 dark:border-gray-800">
+                <Card className="shadow-sm border-gray-200 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                       Finansal Bilgiler
@@ -684,7 +684,7 @@ export default function KrediDuzenlePage() {
                 </Card>
 
                 {/* Tarih ve Taksit Bilgileri */}
-                <Card className="shadow-sm border-gray-200 dark:border-gray-800">
+                <Card className="shadow-sm border-gray-200 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
 
@@ -747,7 +747,7 @@ export default function KrediDuzenlePage() {
                 </Card>
 
                 {/* Teminat ve Sigorta */}
-                <Card className="shadow-sm border-gray-200 dark:border-gray-800">
+                <Card className="shadow-sm border-gray-200 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
 
@@ -783,7 +783,7 @@ export default function KrediDuzenlePage() {
             {/* Ödeme Planı Tab */}
             {activeTab === "payment-plan" && (
               <div className="space-y-6">
-                <Card className="shadow-sm border-gray-200 dark:border-gray-800">
+                <Card className="shadow-sm border-gray-200 dark:border-white/10">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                       <CalendarDays className="h-5 w-5 text-blue-600 dark:text-blue-400" />
@@ -795,12 +795,12 @@ export default function KrediDuzenlePage() {
                     {loadingPaymentPlans ? (
                       <div className="flex items-center justify-center py-8">
                         <Loader2 className="h-8 w-8 animate-spin text-blue-600 dark:text-blue-400" />
-                        <span className="ml-2 text-gray-600 dark:text-gray-400">Ödeme planı yükleniyor...</span>
+                        <span className="ml-2 text-gray-600 dark:text-white/60">Ödeme planı yükleniyor...</span>
                       </div>
                     ) : paymentPlans.length === 0 ? (
                       <div className="text-center py-8">
                         <CalendarDays className="h-12 w-12 text-gray-400 dark:text-gray-600 mx-auto mb-4" />
-                        <p className="text-gray-600 dark:text-gray-400">Bu kredi için ödeme planı bulunamadı.</p>
+                        <p className="text-gray-600 dark:text-white/60">Bu kredi için ödeme planı bulunamadı.</p>
                       </div>
                     ) : (
                       <div className="overflow-x-auto">

--- a/app/uygulama/krediler/page.tsx
+++ b/app/uygulama/krediler/page.tsx
@@ -397,13 +397,13 @@ export default function KredilerPage() {
       </div>
 
       {/* Modern Tabs */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-4 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="tumKrediler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <CreditCard className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Tüm Krediler</span>
@@ -411,7 +411,7 @@ export default function KredilerPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="aktifKrediler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <CheckCircle className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Aktif</span>
@@ -419,7 +419,7 @@ export default function KredilerPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="gecikmisKrediler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <AlertCircle className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Gecikmiş</span>
@@ -427,7 +427,7 @@ export default function KredilerPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="kapaliKrediler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Archive className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Kapalı</span>
@@ -437,7 +437,7 @@ export default function KredilerPage() {
           </div>
 
           {/* Search, Sort and View Toggle */}
-          <div className="p-4 border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+          <div className="p-4 border-b border-gray-100 dark:border-white/10 bg-white dark:bg-black/20">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div className="flex gap-2">
                 <div className="relative">
@@ -453,23 +453,23 @@ export default function KredilerPage() {
                   <DropdownMenuTrigger asChild>
                     <Button
                       variant="outline"
-                      className="flex items-center gap-2 bg-transparent dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      className="flex items-center gap-2 bg-transparent dark:bg-black/10 dark:border-white/10 dark:text-white"
                     >
                       <ArrowUpDown className="h-4 w-4" />
                       Sırala: {sortBy === "kalanBorc" ? "Kalan Borç" : "Son Ödeme Tarihi"} (
                       {sortOrder === "asc" ? "Artan" : "Azalan"})
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="dark:bg-gray-800 dark:border-gray-700">
+                  <DropdownMenuContent align="start" className="dark:bg-black/10 dark:border-white/10">
                     <DropdownMenuItem
                       onClick={() => handleSort("kalanBorc")}
-                      className="dark:text-white dark:hover:bg-gray-700"
+                      className="dark:text-white dark:hover:bg-black/10"
                     >
                       Kalan Borca Göre
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={() => handleSort("sonOdemeTarihi")}
-                      className="dark:text-white dark:hover:bg-gray-700"
+                      className="dark:text-white dark:hover:bg-black/10"
                     >
                       Son Ödeme Tarihine Göre
                     </DropdownMenuItem>
@@ -478,12 +478,12 @@ export default function KredilerPage() {
               </div>
 
               {/* View Mode Toggle */}
-              <div className="flex border rounded-lg dark:border-gray-700">
+              <div className="flex border rounded-lg dark:border-white/10">
                 <Button
                   variant={viewMode === "cards" ? "default" : "ghost"}
                   size="sm"
                   onClick={() => handleViewModeChange("cards")}
-                  className={`rounded-r-none ${viewMode === "cards" ? "bg-gradient-to-r from-emerald-600 to-teal-700 hover:from-emerald-700 hover:to-teal-800" : "dark:text-white dark:hover:bg-gray-700"}`}
+                  className={`rounded-r-none ${viewMode === "cards" ? "bg-gradient-to-r from-emerald-600 to-teal-700 hover:from-emerald-700 hover:to-teal-800" : "dark:text-white dark:hover:bg-black/10"}`}
                 >
                   <BsFillGrid3X3GapFill className="h-4 w-4" />
                 </Button>
@@ -491,7 +491,7 @@ export default function KredilerPage() {
                   variant={viewMode === "table" ? "default" : "ghost"}
                   size="sm"
                   onClick={() => handleViewModeChange("table")}
-                  className={`rounded-l-none ${viewMode === "table" ? "bg-gradient-to-r from-emerald-600 to-teal-700 hover:from-emerald-700 hover:to-teal-800" : "dark:text-white dark:hover:bg-gray-700"}`}
+                  className={`rounded-l-none ${viewMode === "table" ? "bg-gradient-to-r from-emerald-600 to-teal-700 hover:from-emerald-700 hover:to-teal-800" : "dark:text-white dark:hover:bg-black/10"}`}
                 >
                   <List className="h-4 w-4" />
                 </Button>
@@ -500,12 +500,12 @@ export default function KredilerPage() {
           </div>
 
           {/* Content */}
-          <div className="p-6 dark:bg-gray-900">
+          <div className="p-6 dark:bg-black/20">
             {currentItems.length === 0 && !loadingData && (
               <div className="text-center py-10">
                 <CreditCard className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600" />
                 <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">Kredi Bulunamadı</h3>
-                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-sm text-gray-500 dark:text-white/60">
                   {activeTab === "tumKrediler" ? "Hiç kredi eklenmemiş." : "Bu filtreye uygun kredi bulunamadı."}
                 </p>
                 <div className="mt-6">
@@ -526,7 +526,7 @@ export default function KredilerPage() {
                   {currentItems.map((kredi) => (
                     <Card
                       key={kredi.id}
-                      className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-gray-700 overflow-hidden dark:bg-gray-800"
+                      className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-white/10 overflow-hidden dark:bg-black/10"
                     >
                       <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700">
                         <div className="flex items-center justify-between">
@@ -557,16 +557,16 @@ export default function KredilerPage() {
                           </Badge>
                         </div>
                       </CardHeader>
-                      <CardContent className="space-y-5 pt-4 dark:bg-gray-800">
+                      <CardContent className="space-y-5 pt-4 dark:bg-black/10">
                         <div className="grid grid-cols-2 gap-4">
                           <div>
-                            <p className="text-sm text-gray-500 dark:text-gray-400">Kalan Borç</p>
+                            <p className="text-sm text-gray-500 dark:text-white/60">Kalan Borç</p>
                             <p className="text-lg font-semibold text-gray-900 dark:text-white">
                               {formatCurrency(kredi.remaining_debt)}
                             </p>
                           </div>
                           <div>
-                            <p className="text-sm text-gray-500 dark:text-gray-400">Sonraki Ödeme</p>
+                            <p className="text-sm text-gray-500 dark:text-white/60">Sonraki Ödeme</p>
                             <p className="text-lg font-semibold text-gray-900 dark:text-white">
                               {formatCurrency(kredi.nextPaymentAmount || kredi.monthly_payment)}
                             </p>
@@ -575,7 +575,7 @@ export default function KredilerPage() {
 
                         <div>
                           <div className="flex justify-between text-sm mb-2">
-                            <span className="text-gray-500 dark:text-gray-400">Ödeme İlerlemesi</span>
+                            <span className="text-gray-500 dark:text-white/60">Ödeme İlerlemesi</span>
                             <span className="font-medium text-gray-900 dark:text-white">
                               {formatPercent(kredi.payment_progress || 0)}
                             </span>
@@ -585,13 +585,13 @@ export default function KredilerPage() {
 
                         <div className="grid grid-cols-2 gap-4 text-sm">
                           <div>
-                            <p className="text-gray-500 dark:text-gray-400">Faiz Oranı</p>
+                            <p className="text-gray-500 dark:text-white/60">Faiz Oranı</p>
                             <p className="font-medium text-orange-600 dark:text-orange-400">
                               {formatPercent(kredi.interest_rate)}
                             </p>
                           </div>
                           <div>
-                            <p className="text-gray-500 dark:text-gray-400">Kalan Taksit</p>
+                            <p className="text-gray-500 dark:text-white/60">Kalan Taksit</p>
                             <p className="font-medium text-gray-900 dark:text-white">
                               {kredi.remaining_installments || 0}
                             </p>
@@ -602,7 +602,7 @@ export default function KredilerPage() {
                           <Button
                             size="sm"
                             variant="outline"
-                            className="flex-1 border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent"
+                            className="flex-1 border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent"
                             onClick={() => router.push(`/uygulama/kredi-detay/${kredi.id}`)}
                           >
                             <Eye className="mr-2 h-4 w-4" />
@@ -611,7 +611,7 @@ export default function KredilerPage() {
                           <Button
                             size="sm"
                             variant="outline"
-                            className="border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent"
+                            className="border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent"
                             onClick={() => router.push(`/uygulama/kredi-duzenle/${kredi.id}`)}
                           >
                             <Edit className="h-4 w-4" />
@@ -621,19 +621,19 @@ export default function KredilerPage() {
                               <Button
                                 size="sm"
                                 variant="outline"
-                                className="border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 bg-transparent"
+                                className="border-gray-300 dark:border-white/10 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10 hover:border-gray-400 bg-transparent"
                               >
                                 <MoreHorizontal className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="dark:bg-gray-800 dark:border-gray-700">
+                            <DropdownMenuContent align="end" className="dark:bg-black/10 dark:border-white/10">
                               <DropdownMenuItem
                                 onClick={() => router.push(`/uygulama/kredi-detay/${kredi.id}/odeme-plani`)}
-                                className="dark:text-white dark:hover:bg-gray-700"
+                                className="dark:text-white dark:hover:bg-black/10"
                               >
                                 Ödeme Planı
                               </DropdownMenuItem>
-                              <DropdownMenuItem className="dark:text-white dark:hover:bg-gray-700">
+                              <DropdownMenuItem className="dark:text-white dark:hover:bg-black/10">
                                 Rapor Al
                               </DropdownMenuItem>
                               <DropdownMenuItem
@@ -667,9 +667,9 @@ export default function KredilerPage() {
                 <div className="overflow-x-auto">
                   <Table>
                     <TableHeader>
-                      <TableRow className="bg-white dark:bg-gray-900 border-b dark:border-gray-800">
+                      <TableRow className="bg-white dark:bg-black/20 border-b dark:border-white/10">
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("bankaAdi")}
                         >
                           <div className="flex items-center gap-1">
@@ -678,7 +678,7 @@ export default function KredilerPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("tur")}
                         >
                           <div className="flex items-center gap-1">
@@ -687,7 +687,7 @@ export default function KredilerPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("kalanBorc")}
                         >
                           <div className="flex items-center gap-1">
@@ -696,7 +696,7 @@ export default function KredilerPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("sonOdemeTarihi")}
                         >
                           <div className="flex items-center gap-1">
@@ -705,7 +705,7 @@ export default function KredilerPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("faizOrani")}
                         >
                           <div className="flex items-center gap-1">
@@ -713,9 +713,9 @@ export default function KredilerPage() {
                             <ArrowUpDown className="h-3 w-3" />
                           </div>
                         </TableHead>
-                        <TableHead className="font-semibold text-gray-700 dark:text-gray-300">İlerleme</TableHead>
-                        <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Durum</TableHead>
-                        <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-gray-300">
+                        <TableHead className="font-semibold text-gray-700 dark:text-white/70">İlerleme</TableHead>
+                        <TableHead className="font-semibold text-gray-700 dark:text-white/70">Durum</TableHead>
+                        <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-white/70">
                           İşlemler
                         </TableHead>
                       </TableRow>
@@ -725,8 +725,8 @@ export default function KredilerPage() {
                         <TableRow
                           key={kredi.id}
                           onClick={() => router.push(`/uygulama/kredi-detay/${kredi.id}`)}
-                          className={`cursor-pointer hover:bg-emerald-50 dark:hover:bg-gray-800 transition-colors duration-150 ease-in-out ${
-                            index % 2 === 0 ? "bg-white dark:bg-gray-900" : "bg-gray-50/50 dark:bg-gray-800/50"
+                          className={`cursor-pointer hover:bg-emerald-50 dark:hover:bg-black/10 transition-colors duration-150 ease-in-out ${
+                            index % 2 === 0 ? "bg-white dark:bg-black/20" : "bg-gray-50/50 dark:bg-black/10/50"
                           }`}
                         >
                           <TableCell>
@@ -735,7 +735,7 @@ export default function KredilerPage() {
                                 bankName={kredi.banks?.name || "Bilinmeyen Banka"}
                                 logoUrl={kredi.banks?.logo_url ?? undefined}
                                 size="md"
-                                className="ring-1 ring-emerald-200 dark:ring-gray-700 bg-white dark:bg-gray-800"
+                                className="ring-1 ring-emerald-200 dark:ring-gray-700 bg-white dark:bg-black/10"
                               />
                               <div>
                                 <span className="font-medium text-gray-900 dark:text-white block">
@@ -747,13 +747,13 @@ export default function KredilerPage() {
                               </div>
                             </div>
                           </TableCell>
-                          <TableCell className="text-gray-600 dark:text-gray-300">
+                          <TableCell className="text-gray-600 dark:text-white/70">
                             {kredi.credit_types?.name || "N/A"}
                           </TableCell>
                           <TableCell className="font-semibold text-gray-900 dark:text-white">
                             {formatCurrency(kredi.remaining_debt)}
                           </TableCell>
-                          <TableCell className="text-gray-600 dark:text-gray-300">
+                          <TableCell className="text-gray-600 dark:text-white/70">
                             {formatCurrency(kredi.nextPaymentAmount || kredi.monthly_payment)}
                           </TableCell>
                           <TableCell className="font-medium text-orange-600 dark:text-orange-400">
@@ -762,7 +762,7 @@ export default function KredilerPage() {
                           <TableCell>
                             <div className="flex items-center gap-2">
                               <Progress value={kredi.payment_progress || 0} className="h-2 w-16" />
-                              <span className="text-sm font-medium text-gray-600 dark:text-gray-300">
+                              <span className="text-sm font-medium text-gray-600 dark:text-white/70">
                                 {formatPercent(kredi.payment_progress || 0)}
                               </span>
                             </div>
@@ -781,29 +781,29 @@ export default function KredilerPage() {
                                 <Button
                                   variant="ghost"
                                   size="icon"
-                                  className="h-8 w-8 hover:bg-emerald-50 hover:text-emerald-600 dark:hover:bg-teal-900/20 dark:text-gray-300"
+                                  className="h-8 w-8 hover:bg-emerald-50 hover:text-emerald-600 dark:hover:bg-teal-900/20 dark:text-white/70"
                                 >
                                   <MoreHorizontal className="h-4 w-4" />
                                   <span className="sr-only">Actions</span>
                                 </Button>
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" className="dark:bg-gray-800 dark:border-gray-700">
+                              <DropdownMenuContent align="end" className="dark:bg-black/10 dark:border-white/10">
                                 <DropdownMenuItem
                                   onClick={() => router.push(`/uygulama/kredi-detay/${kredi.id}`)}
-                                  className="dark:text-white dark:hover:bg-gray-700"
+                                  className="dark:text-white dark:hover:bg-black/10"
                                 >
                                   <Eye className="mr-2 h-4 w-4" />
                                   Detayları Gör
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onClick={() => router.push(`/uygulama/kredi-duzenle/${kredi.id}`)}
-                                  className="dark:text-white dark:hover:bg-gray-700"
+                                  className="dark:text-white dark:hover:bg-black/10"
                                 >
                                   <Edit className="mr-2 h-4 w-4" />
                                   Düzenle
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
-                                  className="text-red-600 dark:text-red-400 dark:hover:bg-gray-700"
+                                  className="text-red-600 dark:text-red-400 dark:hover:bg-black/10"
                                   onClick={() => handleDeleteCredit(kredi.id)}
                                 >
                                   <Trash2 className="mr-2 h-4 w-4" />
@@ -834,10 +834,10 @@ export default function KredilerPage() {
       </div>
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent className="dark:bg-gray-800 dark:border-gray-700">
+        <AlertDialogContent className="dark:bg-black/10 dark:border-white/10">
           <AlertDialogHeader>
             <AlertDialogTitle className="dark:text-white">Krediyi Sil</AlertDialogTitle>
-            <AlertDialogDescription className="dark:text-gray-300">
+            <AlertDialogDescription className="dark:text-white/70">
               Bu hesabı silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -847,7 +847,7 @@ export default function KredilerPage() {
                 setShowDeleteDialog(false)
                 setCreditToDelete(null)
               }}
-              className="border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+              className="border-gray-300 dark:border-gray-600 text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-black/10"
             >
               İptal
             </AlertDialogCancel>

--- a/app/uygulama/krediler/pdf-odeme-plani/page.tsx
+++ b/app/uygulama/krediler/pdf-odeme-plani/page.tsx
@@ -259,13 +259,13 @@ export default function PDFOdemePlaniPage() {
         </div>
       </Card>
 
-      <Card className="shadow-lg border-gray-200 dark:border-gray-700 rounded-2xl overflow-hidden dark:bg-gray-900">
-        <CardHeader className="bg-gradient-to-r from-gray-50 to-purple-50 dark:from-gray-800 dark:to-purple-900/30 border-b dark:border-gray-700">
+      <Card className="shadow-lg border-gray-200 dark:border-white/10 rounded-2xl overflow-hidden dark:bg-black/20">
+        <CardHeader className="bg-gradient-to-r from-gray-50 to-purple-50 dark:from-gray-800 dark:to-purple-900/30 border-b dark:border-white/10">
           <CardTitle className="flex items-center gap-2 dark:text-white">
             <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             PDF Dosyası Yükle
           </CardTitle>
-          <CardDescription className="dark:text-gray-400">Bankanızdan aldığınız ödeme planı PDF'ini yükleyin</CardDescription>
+          <CardDescription className="dark:text-white/60">Bankanızdan aldığınız ödeme planı PDF'ini yükleyin</CardDescription>
         </CardHeader>
         <CardContent className="p-8">
           <div
@@ -293,12 +293,12 @@ export default function PDFOdemePlaniPage() {
                 </>
               ) : (
                 <>
-                  <Upload className="h-16 w-16 text-gray-400 dark:text-gray-500" />
+                  <Upload className="h-16 w-16 text-gray-400 dark:text-white/60" />
                   <div>
-                    <p className="text-xl font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    <p className="text-xl font-medium text-gray-700 dark:text-white/70 mb-2">
                       {isDragActive ? "Dosyayı buraya bırakın" : "PDF dosyasını sürükleyin veya seçin"}
                     </p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">Maksimum 10MB - Küçük dosyalar daha hızlı</p>
+                    <p className="text-sm text-gray-500 dark:text-white/60">Maksimum 10MB - Küçük dosyalar daha hızlı</p>
                   </div>
                 </>
               )}
@@ -316,10 +316,10 @@ export default function PDFOdemePlaniPage() {
             <div className="space-y-4 mt-6">
               <div className="flex items-center gap-2">
                 <Loader2 className="mr-2 h-5 w-5 animate-spin text-purple-600 dark:text-purple-400" />
-                <span className="text-sm font-medium dark:text-gray-300">PDF hızlı analiz ediliyor...</span>
+                <span className="text-sm font-medium dark:text-white/70">PDF hızlı analiz ediliyor...</span>
               </div>
               <Progress value={progress} className="h-3" />
-              <p className="text-xs text-gray-500 dark:text-gray-400">Optimize edilmiş AI ile 3-5 saniyede tamamlanacak</p>
+              <p className="text-xs text-gray-500 dark:text-white/60">Optimize edilmiş AI ile 3-5 saniyede tamamlanacak</p>
             </div>
           )}
 
@@ -376,7 +376,7 @@ export default function PDFOdemePlaniPage() {
             transition={{ duration: 0.6, delay: 0.5 + index * 0.1 }}
             whileHover={{ y: -5 }}
           >
-            <Card className="text-center p-6 border-0 shadow-lg hover:shadow-xl transition-all duration-300 rounded-2xl dark:bg-gray-900 dark:border-gray-800">
+            <Card className="text-center p-6 border-0 shadow-lg hover:shadow-xl transition-all duration-300 rounded-2xl dark:bg-black/20 dark:border-white/10">
               <motion.div
                 className={`w-14 h-14 bg-gradient-to-br ${feature.color} rounded-2xl flex items-center justify-center mx-auto mb-4`}
                 whileHover={{ scale: 1.1, rotate: 5 }}
@@ -385,7 +385,7 @@ export default function PDFOdemePlaniPage() {
                 <feature.icon className="h-7 w-7 text-white" />
               </motion.div>
               <h3 className="font-bold text-lg mb-2 text-gray-900 dark:text-white">{feature.title}</h3>
-              <p className="text-gray-600 dark:text-gray-400">{feature.description}</p>
+              <p className="text-gray-600 dark:text-white/60">{feature.description}</p>
             </Card>
           </motion.div>
         ))}

--- a/app/uygulama/layout.tsx
+++ b/app/uygulama/layout.tsx
@@ -18,7 +18,7 @@ export default function UygulamaLayout({
       <AuthGuard requireAuth={true}>
         <UserThemeProvider>
           <SidebarProvider defaultOpen={true}>
-        <div className="min-h-screen flex w-full bg-gray-50 dark:bg-gray-950 relative">
+        <div className="min-h-screen flex w-full bg-gray-50 dark:bg-[#151515] relative">
           {/* Desktop Sidebar */}
           <Sidebar collapsible="icon" className="border-r hidden md:flex z-30">
             <SidebarContent>

--- a/app/uygulama/odeme-detay/[id]/page.tsx
+++ b/app/uygulama/odeme-detay/[id]/page.tsx
@@ -129,7 +129,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
               <FileText className="h-12 w-12 mx-auto" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Ödeme Detayı Bulunamadı</h3>
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
+            <p className="text-gray-600 dark:text-white/60 mb-4">
               {error || "Aradığınız ödeme detayı bulunamadı veya erişim izniniz bulunmuyor."}
             </p>
             <Button onClick={() => router.back()}>
@@ -225,7 +225,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
               </h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Ödeme Tarihi:</span>
+                  <span className="text-gray-600 dark:text-white/60">Ödeme Tarihi:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100">
                     {new Date(payment.payment_date).toLocaleDateString("tr-TR", {
                       weekday: "long",
@@ -236,7 +236,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Ödeme Saati:</span>
+                  <span className="text-gray-600 dark:text-white/60">Ödeme Saati:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100">
                     {new Date(payment.created_at).toLocaleTimeString("tr-TR", {
                       hour: "2-digit",
@@ -246,20 +246,20 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Ödeme Kanalı:</span>
+                  <span className="text-gray-600 dark:text-white/60">Ödeme Kanalı:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100">
                     {payment.payment_channel || "Belirtilmemiş"}
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Referans No:</span>
+                  <span className="text-gray-600 dark:text-white/60">Referans No:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
                     {payment.transaction_id || "N/A"}
                   </span>
                 </div>
                 {payment.transaction_id && (
                   <div className="flex justify-between">
-                    <span className="text-gray-600 dark:text-gray-400">İşlem ID:</span>
+                    <span className="text-gray-600 dark:text-white/60">İşlem ID:</span>
                     <span className="font-medium text-gray-900 dark:text-gray-100 font-mono text-sm">
                       {payment.transaction_id}
                     </span>
@@ -275,24 +275,24 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
               </h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Banka:</span>
+                  <span className="text-gray-600 dark:text-white/60">Banka:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100">{payment.credits.banks.name}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Kredi Türü:</span>
+                  <span className="text-gray-600 dark:text-white/60">Kredi Türü:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100">
                     {payment.credits.credit_types.name}
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600 dark:text-gray-400">Kredi Kodu:</span>
+                  <span className="text-gray-600 dark:text-white/60">Kredi Kodu:</span>
                   <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
                     {payment.credits.credit_code}
                   </span>
                 </div>
                 {payment.credits.account_number && (
                   <div className="flex justify-between">
-                    <span className="text-gray-600 dark:text-gray-400">Hesap No:</span>
+                    <span className="text-gray-600 dark:text-white/60">Hesap No:</span>
                     <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
                       {payment.credits.account_number}
                     </span>
@@ -310,7 +310,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
               <Hash className="h-5 w-5 text-purple-600" />
               Ödeme Detayı
             </h3>
-            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
+            <div className="bg-gray-50 dark:bg-black/10 rounded-lg p-4">
               <div className="flex justify-between items-center">
                 <span className="text-lg font-medium text-gray-900 dark:text-gray-100">Ödenen Tutar:</span>
                 <span className="text-2xl font-bold text-emerald-600">{formatCurrency(payment.amount)}</span>
@@ -328,7 +328,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
                   Notlar
                 </h3>
                 <div className="bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg p-4">
-                  <p className="text-gray-700 dark:text-gray-300">{payment.notes}</p>
+                  <p className="text-gray-700 dark:text-white/70">{payment.notes}</p>
                 </div>
               </div>
             </>
@@ -336,7 +336,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
 
           {/* Footer */}
           <Separator />
-          <div className="text-center text-sm text-gray-500 dark:text-gray-400 space-y-1">
+          <div className="text-center text-sm text-gray-500 dark:text-white/60 space-y-1">
             <p>Bu makbuz kreditakip.com.tr sistemi tarafından otomatik olarak oluşturulmuştur.</p>
             <p>
               Makbuz Tarihi: {new Date().toLocaleDateString("tr-TR")} {new Date().toLocaleTimeString("tr-TR")}

--- a/app/uygulama/odeme-plani/page.tsx
+++ b/app/uygulama/odeme-plani/page.tsx
@@ -211,7 +211,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
             variant="outline"
             size="sm"
             onClick={handlePrevMonth}
-            className="flex items-center gap-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="flex items-center gap-2 bg-white dark:bg-black/10 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-black/10"
           >
             <ChevronLeft className="h-4 w-4" />
             Önceki
@@ -225,7 +225,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
             variant="outline"
             size="sm"
             onClick={handleNextMonth}
-            className="flex items-center gap-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="flex items-center gap-2 bg-white dark:bg-black/10 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-black/10"
           >
             Sonraki
             <ChevronRight className="h-4 w-4" />
@@ -238,34 +238,34 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
               <Button
                 variant="outline"
                 size="sm"
-                className="bg-white dark:bg-gray-800 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+                className="bg-white dark:bg-black/10 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-black/10"
               >
                 <Filter className="h-4 w-4 mr-2" />
                 Filtrele: {filterStatus === "all" ? "Tümü" : filterStatus === "paid" ? "Ödendi" : filterStatus === "pending" ? "Bekliyor" : "Gecikmiş"}
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="dark:bg-gray-800 dark:border-gray-700">
+            <DropdownMenuContent align="end" className="dark:bg-black/10 dark:border-white/10">
               <DropdownMenuItem
                 onClick={() => setFilterStatus("all")}
-                className="dark:text-white dark:hover:bg-gray-700"
+                className="dark:text-white dark:hover:bg-black/10"
               >
                 Tümü
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => setFilterStatus("paid")}
-                className="dark:text-white dark:hover:bg-gray-700"
+                className="dark:text-white dark:hover:bg-black/10"
               >
                 Ödendi
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => setFilterStatus("pending")}
-                className="dark:text-white dark:hover:bg-gray-700"
+                className="dark:text-white dark:hover:bg-black/10"
               >
                 Bekliyor
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => setFilterStatus("overdue")}
-                className="dark:text-white dark:hover:bg-gray-700"
+                className="dark:text-white dark:hover:bg-black/10"
               >
                 Gecikmiş
               </DropdownMenuItem>
@@ -278,14 +278,14 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
         {dayNames.map((day) => (
           <div
             key={day}
-            className="p-2 text-center text-sm font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-t-lg"
+            className="p-2 text-center text-sm font-medium text-gray-500 dark:text-white/60 bg-gray-50 dark:bg-black/10 rounded-t-lg"
           >
             {day}
           </div>
         ))}
 
         {Array.from({ length: startingDayOfWeek }, (_, i) => (
-          <div key={`empty-${i}`} className="p-2 h-32 bg-gray-50/30 dark:bg-gray-800/30 rounded-lg"></div>
+          <div key={`empty-${i}`} className="p-2 h-32 bg-gray-50/30 dark:bg-black/10/30 rounded-lg"></div>
         ))}
 
         {Array.from({ length: daysInMonth }, (_, i) => {
@@ -301,8 +301,8 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
                 isToday
                   ? "bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 shadow-md ring-2 ring-blue-200 dark:ring-blue-800"
                   : dayPayments.length > 0
-                    ? "bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-600"
-                    : "bg-gray-50/50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700"
+                    ? "bg-white dark:bg-black/20 border-gray-300 dark:border-white/10 hover:border-gray-400 dark:hover:border-gray-600"
+                    : "bg-gray-50/50 dark:bg-black/10/50 border-gray-200 dark:border-white/10"
               }`}
             >
               <div
@@ -311,7 +311,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
                     ? "text-blue-700 dark:text-blue-400"
                     : dayPayments.length > 0
                       ? "text-gray-900 dark:text-white"
-                      : "text-gray-500 dark:text-gray-400"
+                      : "text-gray-500 dark:text-white/60"
                 }`}
               >
                 {day}
@@ -354,7 +354,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
                 })}
 
                 {dayPayments.length > 3 && (
-                  <div className="text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 p-1 rounded text-center">
+                  <div className="text-xs text-gray-600 dark:text-white/70 bg-gray-100 dark:bg-black/10 p-1 rounded text-center">
                     +{dayPayments.length - 3} daha
                   </div>
                 )}
@@ -366,7 +366,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
 
       {uniqueBanks.length > 0 && (
         <div className="mt-6">
-          <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+          <h4 className="text-sm font-semibold text-gray-700 dark:text-white/70 mb-3 flex items-center gap-2">
             <div className="w-2 h-2 bg-gray-400 dark:bg-gray-600 rounded-full"></div>
             Banka Renk Kodları
           </h4>
@@ -374,15 +374,15 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
             {uniqueBanks.map((bank) => (
               <div
                 key={bank.name}
-                className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 dark:bg-gray-800"
+                className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-white/10 dark:bg-black/10"
               >
                 <div className="w-3 h-3 rounded-full shadow-sm" style={{ backgroundColor: bank.color }}></div>
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{bank.name}</span>
+                <span className="text-sm font-medium text-gray-700 dark:text-white/70">{bank.name}</span>
               </div>
             ))}
-            <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-white/10 dark:bg-black/10">
               <div className="w-3 h-3 rounded-full shadow-sm bg-emerald-500"></div>
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Ödenen</span>
+              <span className="text-sm font-medium text-gray-700 dark:text-white/70">Ödenen</span>
               <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
             </div>
           </div>
@@ -624,13 +624,13 @@ function PaymentsList({
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Tüm Ödemeler</h3>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-gray-600 dark:text-white/60">
             Toplam {filteredPayments.length} ödeme • Sayfa {currentPage} / {totalPages}
           </p>
         </div>
         <Button
           variant="outline"
-          className="gap-2 min-w-[140px] bg-transparent dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          className="gap-2 min-w-[140px] bg-transparent dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
           onClick={exportToExcel}
         >
           <Download className="h-4 w-4" />
@@ -641,7 +641,7 @@ function PaymentsList({
       <div className="flex flex-col sm:flex-row gap-4">
         {/* Search */}
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-white/60" />
           <Input
             type="text"
             placeholder="Banka adı veya kredi kodu ara..."
@@ -656,7 +656,7 @@ function PaymentsList({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="gap-2 min-w-[140px] bg-transparent dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              className="gap-2 min-w-[140px] bg-transparent dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
             >
               <Filter className="h-4 w-4" />
               {statusFilter === "all"
@@ -668,36 +668,36 @@ function PaymentsList({
                     : "Geciken"}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48 dark:bg-gray-900 dark:border-gray-700">
+          <DropdownMenuContent align="end" className="w-48 dark:bg-black/20 dark:border-white/10">
             <DropdownMenuItem
               onClick={() => setStatusFilter("all")}
-              className="dark:hover:bg-gray-800 dark:text-gray-300"
+              className="dark:hover:bg-black/10 dark:text-white/70"
             >
               <span className="flex items-center justify-between w-full">
                 Tüm Durumlar
-                <span className="text-xs bg-gray-100 dark:bg-gray-800 dark:text-gray-300 px-2 py-0.5 rounded">
+                <span className="text-xs bg-gray-100 dark:bg-black/10 dark:text-white/70 px-2 py-0.5 rounded">
                   {statusCounts.all}
                 </span>
               </span>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => setStatusFilter("pending")}
-              className="dark:hover:bg-gray-800 dark:text-gray-300"
+              className="dark:hover:bg-black/10 dark:text-white/70"
             >
               <span className="flex items-center justify-between w-full">
                 Bekleyen
-                <span className="text-xs bg-gray-100 dark:bg-gray-800 dark:text-gray-300 px-2 py-0.5 rounded">
+                <span className="text-xs bg-gray-100 dark:bg-black/10 dark:text-white/70 px-2 py-0.5 rounded">
                   {statusCounts.pending}
                 </span>
               </span>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => setStatusFilter("overdue")}
-              className="dark:hover:bg-gray-800 dark:text-gray-300"
+              className="dark:hover:bg-black/10 dark:text-white/70"
             >
               <span className="flex items-center justify-between w-full">
                 Geciken
-                <span className="text-xs bg-gray-100 dark:bg-gray-800 dark:text-gray-300 px-2 py-0.5 rounded">
+                <span className="text-xs bg-gray-100 dark:bg-black/10 dark:text-white/70 px-2 py-0.5 rounded">
                   {statusCounts.overdue}
                 </span>
               </span>
@@ -710,16 +710,16 @@ function PaymentsList({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="gap-2 min-w-[140px] bg-transparent dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              className="gap-2 min-w-[140px] bg-transparent dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
             >
               <CreditCard className="h-4 w-4" />
               {bankFilter === "all" ? "Tüm Bankalar" : bankFilter}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48 dark:bg-gray-900 dark:border-gray-700">
+          <DropdownMenuContent align="end" className="w-48 dark:bg-black/20 dark:border-white/10">
             <DropdownMenuItem
               onClick={() => setBankFilter("all")}
-              className="dark:hover:bg-gray-800 dark:text-gray-300"
+              className="dark:hover:bg-black/10 dark:text-white/70"
             >
               Tüm Bankalar
             </DropdownMenuItem>
@@ -727,7 +727,7 @@ function PaymentsList({
               <DropdownMenuItem
                 key={bank.name}
                 onClick={() => setBankFilter(bank.name)}
-                className="dark:hover:bg-gray-800 dark:text-gray-300"
+                className="dark:hover:bg-black/10 dark:text-white/70"
               >
                 <div className="flex items-center gap-2">
                   <BankLogo bankName={bank.name} size="sm" />
@@ -742,14 +742,14 @@ function PaymentsList({
       <div className="overflow-x-auto">
         <table className="w-full border-collapse">
           <thead>
-            <tr className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Banka</th>
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Taksit No</th>
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Vade Tarihi</th>
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Ana Para</th>
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Faiz</th>
-              <th className="font-semibold text-gray-700 dark:text-gray-300 p-4 text-left">Toplam</th>
-              <th className="w-[100px] text-right font-semibold text-gray-700 dark:text-gray-300 p-4">İşlemler</th>
+            <tr className="bg-white dark:bg-black/20 border-b border-gray-200 dark:border-white/10">
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Banka</th>
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Taksit No</th>
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Vade Tarihi</th>
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Ana Para</th>
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Faiz</th>
+              <th className="font-semibold text-gray-700 dark:text-white/70 p-4 text-left">Toplam</th>
+              <th className="w-[100px] text-right font-semibold text-gray-700 dark:text-white/70 p-4">İşlemler</th>
             </tr>
           </thead>
           <tbody>
@@ -761,8 +761,8 @@ function PaymentsList({
               return (
                 <tr
                   key={payment.id}
-                  className={`hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-150 ease-in-out border-b border-gray-100 dark:border-gray-800 ${
-                    index % 2 === 0 ? "bg-white dark:bg-gray-900" : "bg-gray-50/50 dark:bg-gray-800/50"
+                  className={`hover:bg-gray-50 dark:hover:bg-black/10 transition-colors duration-150 ease-in-out border-b border-gray-100 dark:border-white/10 ${
+                    index % 2 === 0 ? "bg-white dark:bg-black/20" : "bg-gray-50/50 dark:bg-black/10/50"
                   }`}
                 >
                   <td className="p-4">
@@ -774,12 +774,12 @@ function PaymentsList({
                       />
                       <div>
                         <div className="font-medium text-gray-900 dark:text-white">{payment.credits.banks.name}</div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">{payment.credits.credit_code}</div>
+                        <div className="text-xs text-gray-500 dark:text-white/60">{payment.credits.credit_code}</div>
                       </div>
                     </div>
                   </td>
                   <td className="p-4 font-medium text-teal-700 dark:text-teal-400">#{payment.installment_number}</td>
-                  <td className="p-4 text-gray-600 dark:text-gray-300">{formatDate(payment.due_date)}</td>
+                  <td className="p-4 text-gray-600 dark:text-white/70">{formatDate(payment.due_date)}</td>
                   <td className="p-4 font-semibold text-gray-900 dark:text-white">
                     {formatCurrency(payment.principal_amount)}
                   </td>
@@ -834,7 +834,7 @@ function PaymentsList({
       </div>
 
       {currentPayments.length === 0 && (
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        <div className="text-center py-12 text-gray-500 dark:text-white/60">
           <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
           <h3 className="font-medium text-gray-900 dark:text-white mb-2">Ödeme Bulunamadı</h3>
           <p className="text-sm">Seçilen filtrelere uygun ödeme bulunmuyor</p>
@@ -843,7 +843,7 @@ function PaymentsList({
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
-          <div className="text-sm text-gray-600 dark:text-gray-400">
+          <div className="text-sm text-gray-600 dark:text-white/60">
             {startIndex + 1}-{Math.min(endIndex, filteredPayments.length)} arası, toplam {filteredPayments.length} ödeme
           </div>
 
@@ -853,7 +853,7 @@ function PaymentsList({
               size="sm"
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage === 1}
-              className="dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              className="dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
             >
               <ChevronLeft className="h-4 w-4" />
               Önceki
@@ -877,7 +877,7 @@ function PaymentsList({
                     key={pageNum}
                     variant={currentPage === pageNum ? "default" : "outline"}
                     size="sm"
-                    className="w-8 h-8 p-0 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                    className="w-8 h-8 p-0 dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
                     onClick={() => setCurrentPage(pageNum)}
                   >
                     {pageNum}
@@ -891,7 +891,7 @@ function PaymentsList({
               size="sm"
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage === totalPages}
-              className="dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              className="dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
             >
               Sonraki
               <ChevronRight className="h-4 w-4" />
@@ -984,7 +984,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h3 className="text-xl font-semibold dark:text-white">Ödeme Analizi</h3>
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="text-sm text-gray-500 dark:text-white/60">
           Son güncelleme: {new Date().toLocaleDateString("tr-TR")}
         </div>
       </div>
@@ -1061,7 +1061,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card className="dark:bg-gray-900 dark:border-gray-800">
+        <Card className="dark:bg-black/20 dark:border-white/10">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 dark:text-white">
               <CreditCard className="h-5 w-5" />
@@ -1094,7 +1094,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
                           }}
                         ></div>
                       </div>
-                      <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400">
+                      <div className="flex justify-between text-xs text-gray-600 dark:text-white/60">
                         <span>{data.count} taksit</span>
                         <span>Bekleyen: {formatCurrency(data.pending)}</span>
                       </div>
@@ -1105,7 +1105,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-900 dark:border-gray-800">
+        <Card className="dark:bg-black/20 dark:border-white/10">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 dark:text-white">
               <TrendingUp className="h-5 w-5" />
@@ -1138,7 +1138,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
                       ></div>
                     </div>
                   </div>
-                  <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400">
+                  <div className="flex justify-between text-xs text-gray-600 dark:text-white/60">
                     <span className="flex items-center gap-1">
                       <div className="w-2 h-2 bg-emerald-500 rounded-full"></div>
                       Ödenen: {formatCurrency(month.paid)}
@@ -1155,7 +1155,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
         </Card>
       </div>
 
-      <Card className="dark:bg-gray-900 dark:border-gray-800">
+      <Card className="dark:bg-black/20 dark:border-white/10">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 dark:text-white">
             <CheckCircle className="h-5 w-5" />
@@ -1166,19 +1166,19 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="text-center">
               <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{paidThisYear.length}</div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Ödenen Taksit</p>
+              <p className="text-sm text-gray-600 dark:text-white/60">Ödenen Taksit</p>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
                 {formatCurrency(totalPaidThisYear)}
               </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Toplam Ödenen</p>
+              <p className="text-sm text-gray-600 dark:text-white/60">Toplam Ödenen</p>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
                 {payments.filter((p) => p.status === "pending").length}
               </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Kalan Taksit</p>
+              <p className="text-sm text-gray-600 dark:text-white/60">Kalan Taksit</p>
             </div>
           </div>
         </CardContent>
@@ -1256,7 +1256,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
   if (!preferences) {
     return (
       <div className="text-center py-8">
-        <p className="text-gray-600 dark:text-gray-400">Bildirim tercihleri yüklenemedi</p>
+        <p className="text-gray-600 dark:text-white/60">Bildirim tercihleri yüklenemedi</p>
       </div>
     )
   }
@@ -1272,13 +1272,13 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h3 className="text-xl font-semibold dark:text-white">Hatırlatıcı Ayarları</h3>
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <div className="text-sm text-gray-500 dark:text-white/60">
           Son güncelleme: {new Date(preferences.updated_at).toLocaleDateString("tr-TR")}
         </div>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <Card className="dark:bg-gray-900 dark:border-gray-800">
+        <Card className="dark:bg-black/20 dark:border-white/10">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 dark:text-white">
               <Bell className="h-5 w-5" />
@@ -1289,7 +1289,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">3 gün önceden hatırlat</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Vade tarihinden 3 gün önce e-posta gönder</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Vade tarihinden 3 gün önce e-posta gönder</p>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -1299,7 +1299,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                   disabled={updating === "email_3_days_before"}
                   className={
                     !preferences.email_3_days_before
-                      ? "dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                      ? "dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
                       : ""
                   }
                 >
@@ -1317,7 +1317,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">1 gün önceden hatırlat</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Vade tarihinden 1 gün önce e-posta gönder</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Vade tarihinden 1 gün önce e-posta gönder</p>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -1327,7 +1327,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                   disabled={updating === "email_1_day_before"}
                   className={
                     !preferences.email_1_day_before
-                      ? "dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                      ? "dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
                       : ""
                   }
                 >
@@ -1345,7 +1345,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">Vade günü hatırlat</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Vade gününde e-posta gönder</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Vade gününde e-posta gönder</p>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -1355,7 +1355,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                   disabled={updating === "email_on_due_date"}
                   className={
                     !preferences.email_on_due_date
-                      ? "dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                      ? "dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10"
                       : ""
                   }
                 >
@@ -1373,7 +1373,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">Gecikme bildirimi</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Vade geçtiğinde e-posta gönder</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Vade geçtiğinde e-posta gönder</p>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -1382,7 +1382,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                   onClick={() => togglePreference("email_overdue", preferences.email_overdue)}
                   disabled={updating === "email_overdue"}
                   className={
-                    !preferences.email_overdue ? "dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800" : ""
+                    !preferences.email_overdue ? "dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10" : ""
                   }
                 >
                   {updating === "email_overdue" ? (
@@ -1398,7 +1398,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
           </CardContent>
         </Card>
 
-        <Card className="dark:bg-gray-900 dark:border-gray-800">
+        <Card className="dark:bg-black/20 dark:border-white/10">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 dark:text-white">
               <Clock className="h-5 w-5" />
@@ -1409,7 +1409,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">E-posta bildirimleri</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Tüm e-posta bildirimlerini aç/kapat</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Tüm e-posta bildirimlerini aç/kapat</p>
               </div>
               <Button
                 variant={preferences.email_enabled ? "default" : "outline"}
@@ -1417,7 +1417,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                 onClick={() => togglePreference("email_enabled", preferences.email_enabled)}
                 disabled={updating === "email_enabled"}
                 className={
-                  !preferences.email_enabled ? "dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800" : ""
+                  !preferences.email_enabled ? "dark:border-white/10 dark:text-white/70 dark:hover:bg-black/10" : ""
                 }
               >
                 {updating === "email_enabled" ? (
@@ -1433,22 +1433,22 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             <div className="flex items-center justify-between">
               <div>
                 <span className="font-medium dark:text-white">Bildirim saati</span>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Bildirimlerin gönderileceği saat</p>
+                <p className="text-sm text-gray-600 dark:text-white/60">Bildirimlerin gönderileceği saat</p>
               </div>
-              <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <div className="text-sm font-medium text-gray-700 dark:text-white/70">
                 {preferences.notification_time}
               </div>
             </div>
 
-            <div className="pt-4 border-t dark:border-gray-700">
-              <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">SMS Bildirimleri (Yakında)</div>
+            <div className="pt-4 border-t dark:border-white/10">
+              <div className="text-sm text-gray-600 dark:text-white/60 mb-2">SMS Bildirimleri (Yakında)</div>
               <div className="flex items-center justify-between opacity-50">
-                <span className="text-sm dark:text-gray-400">SMS bildirimleri</span>
+                <span className="text-sm dark:text-white/60">SMS bildirimleri</span>
                 <Button
                   variant="outline"
                   size="sm"
                   disabled
-                  className="dark:border-gray-700 dark:text-gray-400 bg-transparent"
+                  className="dark:border-white/10 dark:text-white/60 bg-transparent"
                 >
                   Yakında
                 </Button>
@@ -1459,7 +1459,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
       </div>
 
       {/* Yaklaşan Hatırlatııcılar kartına koyu tema desteği eklendi */}
-      <Card className="dark:bg-gray-900 dark:border-gray-800">
+      <Card className="dark:bg-black/20 dark:border-white/10">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 dark:text-white">
             <Calendar className="h-5 w-5" />
@@ -1477,7 +1477,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                 return (
                   <div
                     key={payment.id}
-                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-black/10 rounded-lg"
                   >
                     <div className="flex items-center gap-3">
                       <BankLogo
@@ -1487,7 +1487,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                       />
                       <div>
                         <div className="font-medium dark:text-white">{payment.credits.banks.name}</div>
-                        <div className="text-sm text-gray-600 dark:text-gray-400">
+                        <div className="text-sm text-gray-600 dark:text-white/60">
                           {formatDate(payment.due_date)} - {formatCurrency(payment.total_payment)}
                         </div>
                       </div>
@@ -1499,12 +1499,12 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                             ? "text-red-600 dark:text-red-400"
                             : daysUntilDue <= 3
                               ? "text-orange-600 dark:text-orange-400"
-                              : "text-gray-600 dark:text-gray-400"
+                              : "text-gray-600 dark:text-white/60"
                         }`}
                       >
                         {daysUntilDue === 0 ? "Bugün" : daysUntilDue === 1 ? "Yarın" : `${daysUntilDue} gün kaldı`}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                      <div className="text-xs text-gray-500 dark:text-white/60">
                         #{payment.installment_number}. taksit
                       </div>
                     </div>
@@ -1512,15 +1512,15 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
                 )
               })}
               {upcomingPayments.length > 5 && (
-                <div className="text-center text-sm text-gray-600 dark:text-gray-400 pt-2">
+                <div className="text-center text-sm text-gray-600 dark:text-white/60 pt-2">
                   +{upcomingPayments.length - 5} ödeme daha
                 </div>
               )}
             </div>
           ) : (
-            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+            <div className="text-center py-8 text-gray-500 dark:text-white/60">
               <Bell className="h-12 w-12 mx-auto mb-3 text-gray-400 dark:text-gray-600" />
-              <p className="font-medium dark:text-gray-300">Yaklaşan ödeme yok</p>
+              <p className="font-medium dark:text-white/70">Yaklaşan ödeme yok</p>
               <p className="text-sm">Önümüzdeki 7 gün içinde vadesi gelen ödeme bulunmuyor</p>
             </div>
           )}
@@ -1578,7 +1578,7 @@ export default function OdemePlaniPage() {
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-600 mx-auto mb-4"></div>
-          <p className="text-gray-600 dark:text-gray-400">Yükleniyor...</p>
+          <p className="text-gray-600 dark:text-white/60">Yükleniyor...</p>
         </div>
       </div>
     )
@@ -1622,7 +1622,7 @@ export default function OdemePlaniPage() {
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-600 mx-auto mb-4"></div>
-          <p className="text-gray-600 dark:text-gray-400">Ödeme planları yükleniyor...</p>
+          <p className="text-gray-600 dark:text-white/60">Ödeme planları yükleniyor...</p>
         </div>
       </div>
     )
@@ -1707,34 +1707,34 @@ export default function OdemePlaniPage() {
         </CardContent>
       </Card>
 
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={selectedTab} onValueChange={setSelectedTab} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="takvim"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-400"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/60"
               >
                 <Calendar className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Takvim</span>
               </TabsTrigger>
               <TabsTrigger
                 value="liste"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-400"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/60"
               >
                 <CreditCard className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Liste</span>
               </TabsTrigger>
               <TabsTrigger
                 value="analiz"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-400"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/60"
               >
                 <TrendingUp className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Analiz</span>
               </TabsTrigger>
               <TabsTrigger
                 value="hatirlatici"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-400"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/60"
               >
                 <Bell className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Hatırlatıcı</span>

--- a/app/uygulama/odeme/basarili/page.tsx
+++ b/app/uygulama/odeme/basarili/page.tsx
@@ -63,17 +63,17 @@ export default function PaymentSuccessPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-[#151515]">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600 mx-auto"></div>
-          <p className="text-gray-600 dark:text-gray-400">Yükleniyor...</p>
+          <p className="text-gray-600 dark:text-white/60">Yükleniyor...</p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+    <div className="fixed inset-0 z-50 overflow-y-auto bg-gray-50 dark:bg-[#151515]">
       <div className="min-h-screen flex items-center justify-center p-4 py-12">
         <div
           className={`max-w-2xl w-full space-y-8 transition-all duration-1000 ${
@@ -95,7 +95,7 @@ export default function PaymentSuccessPage() {
           <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent">
             Tebrikler! 🎉
           </h1>
-          <p className="text-xl md:text-2xl text-gray-700 dark:text-gray-300">
+          <p className="text-xl md:text-2xl text-gray-700 dark:text-white/70">
             Premium üyeliğiniz başarıyla aktif edildi
           </p>
         </div>
@@ -112,7 +112,7 @@ export default function PaymentSuccessPage() {
           <CardContent className="pt-6 space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
-                <p className="text-sm text-gray-500 dark:text-gray-400">Plan</p>
+                <p className="text-sm text-gray-500 dark:text-white/60">Plan</p>
                 <p className="font-semibold text-emerald-600 dark:text-emerald-400">
                   {subscription?.planType === "premium"
                     ? subscription?.plan_id === "premium-yearly"
@@ -124,11 +124,11 @@ export default function PaymentSuccessPage() {
                 </p>
               </div>
               <div className="space-y-1">
-                <p className="text-sm text-gray-500 dark:text-gray-400">Durum</p>
+                <p className="text-sm text-gray-500 dark:text-white/60">Durum</p>
                 <p className="font-semibold text-emerald-600 dark:text-emerald-400">Aktif</p>
               </div>
               <div className="space-y-1">
-                <p className="text-sm text-gray-500 dark:text-gray-400">Başlangıç</p>
+                <p className="text-sm text-gray-500 dark:text-white/60">Başlangıç</p>
                 <p className="font-medium">
                   {subscription?.startDate
                     ? new Date(subscription.startDate).toLocaleDateString("tr-TR", {
@@ -140,7 +140,7 @@ export default function PaymentSuccessPage() {
                 </p>
               </div>
               <div className="space-y-1">
-                <p className="text-sm text-gray-500 dark:text-gray-400">Bitiş</p>
+                <p className="text-sm text-gray-500 dark:text-white/60">Bitiş</p>
                 <p className="font-medium">
                   {subscription?.expiresAt
                     ? new Date(subscription.expiresAt).toLocaleDateString("tr-TR", {

--- a/app/uygulama/odeme/page.tsx
+++ b/app/uygulama/odeme/page.tsx
@@ -203,7 +203,7 @@ export default function PaymentPage() {
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600 mx-auto"></div>
-          <p className="text-gray-600 dark:text-gray-400">Yükleniyor...</p>
+          <p className="text-gray-600 dark:text-white/60">Yükleniyor...</p>
         </div>
       </div>
     )
@@ -320,7 +320,7 @@ export default function PaymentPage() {
                       disabled={isProcessing}
                       maxLength={11}
                     />
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-gray-500 dark:text-white/60">
                       Başında 0 ile birlikte 11 hane
                     </p>
                   </div>
@@ -337,7 +337,7 @@ export default function PaymentPage() {
                       required
                       disabled={isProcessing}
                     />
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-gray-500 dark:text-white/60">
                       Ödeme sağlayıcısı tarafından zorunludur
                     </p>
                   </div>
@@ -415,7 +415,7 @@ export default function PaymentPage() {
                       onChange={handleBillingChange}
                       disabled={isProcessing}
                     />
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-gray-500 dark:text-white/60">
                       Kurumsal fatura için gereklidir
                     </p>
                   </div>
@@ -431,7 +431,7 @@ export default function PaymentPage() {
                       maxLength={10}
                       disabled={isProcessing}
                     />
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                    <p className="text-xs text-gray-500 dark:text-white/60">
                       Kurumsal fatura için gereklidir
                     </p>
                   </div>
@@ -449,11 +449,11 @@ export default function PaymentPage() {
               <CardContent className="space-y-4">
                 <div className="space-y-3">
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600 dark:text-gray-400">{selectedPlan.name}:</span>
+                    <span className="text-gray-600 dark:text-white/60">{selectedPlan.name}:</span>
                     <span className="font-medium">{selectedPlan.price}₺</span>
                   </div>
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600 dark:text-gray-400">Periyot:</span>
+                    <span className="text-gray-600 dark:text-white/60">Periyot:</span>
                     <span className="font-medium">{selectedPlan.periodLabel}</span>
                   </div>
                   {selectedPlan.originalPrice && (

--- a/app/uygulama/premium/page.tsx
+++ b/app/uygulama/premium/page.tsx
@@ -112,7 +112,7 @@ export default function PremiumPage() {
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600 mx-auto"></div>
-          <p className="text-gray-600 dark:text-gray-400">Yükleniyor...</p>
+          <p className="text-gray-600 dark:text-white/60">Yükleniyor...</p>
         </div>
       </div>
     )
@@ -156,7 +156,7 @@ export default function PremiumPage() {
       <div className="max-w-4xl mx-auto">
         <div className="grid md:grid-cols-2 gap-8 items-stretch">
           {/* Free Plan */}
-          <Card className="relative border-2 border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow flex flex-col">
+          <Card className="relative border-2 border-gray-200 dark:border-white/10 hover:shadow-lg transition-shadow flex flex-col">
             <CardHeader className="space-y-4">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-2xl">Ücretsiz</CardTitle>
@@ -167,7 +167,7 @@ export default function PremiumPage() {
               <CardDescription className="text-base">Temel özellikler ile başlayın</CardDescription>
               <div className="pt-4">
                 <p className="text-5xl font-bold">
-                  0₺<span className="text-lg font-normal text-gray-600 dark:text-gray-400">/ay</span>
+                  0₺<span className="text-lg font-normal text-gray-600 dark:text-white/60">/ay</span>
                 </p>
               </div>
             </CardHeader>
@@ -183,7 +183,7 @@ export default function PremiumPage() {
                   <div className="p-1 bg-red-100 dark:bg-red-900/30 rounded-full">
                     <X className="h-4 w-4 text-red-600 dark:text-red-400" />
                   </div>
-                  <span className="text-sm text-gray-500 dark:text-gray-400">Risk analizi yok</span>
+                  <span className="text-sm text-gray-500 dark:text-white/60">Risk analizi yok</span>
                 </div>
                 <div className="flex items-start gap-3">
                   <div className="p-1 bg-emerald-100 dark:bg-emerald-900/30 rounded-full">
@@ -201,7 +201,7 @@ export default function PremiumPage() {
                   <div className="p-1 bg-red-100 dark:bg-red-900/30 rounded-full">
                     <X className="h-4 w-4 text-red-600 dark:text-red-400" />
                   </div>
-                  <span className="text-sm text-gray-500 dark:text-gray-400">Reklamlar gösterilir</span>
+                  <span className="text-sm text-gray-500 dark:text-white/60">Reklamlar gösterilir</span>
                 </div>
               </div>
               {!isPremium && (
@@ -236,7 +236,7 @@ export default function PremiumPage() {
               </div>
 
               {/* Toggle Switch */}
-              <div className="flex items-center justify-center gap-3 p-4 bg-white/50 dark:bg-gray-900/50 rounded-xl border border-emerald-200 dark:border-emerald-800">
+              <div className="flex items-center justify-center gap-3 p-4 bg-white/50 dark:bg-black/20/50 rounded-xl border border-emerald-200 dark:border-emerald-800">
                 <span className={`text-sm font-medium transition-colors ${!isYearly ? "text-emerald-600 dark:text-emerald-400" : "text-gray-500"}`}>
                   Aylık
                 </span>
@@ -257,13 +257,13 @@ export default function PremiumPage() {
 
               <div className="pt-4">
                 {isYearly && yearlyPlan?.originalPrice && (
-                  <p className="text-xl text-gray-500 dark:text-gray-400 line-through text-center">
+                  <p className="text-xl text-gray-500 dark:text-white/60 line-through text-center">
                     {yearlyPlan.originalPrice}₺/yıllık
                   </p>
                 )}
                 <p className="text-5xl font-bold text-center">
                   {selectedPlan?.price}₺
-                  <span className="text-lg font-normal text-gray-600 dark:text-gray-400">
+                  <span className="text-lg font-normal text-gray-600 dark:text-white/60">
                     /{isYearly ? "yıl" : "ay"}
                   </span>
                 </p>
@@ -276,7 +276,7 @@ export default function PremiumPage() {
                   </div>
                 )}
                 {!isYearly && (
-                  <p className="text-sm text-gray-600 dark:text-gray-400 text-center mt-2">
+                  <p className="text-sm text-gray-600 dark:text-white/60 text-center mt-2">
                     Yıllık plan ile %17 indirim kazanın
                   </p>
                 )}
@@ -430,10 +430,10 @@ export default function PremiumPage() {
           </DialogHeader>
           <div className="py-4">
             <div className="space-y-3">
-              <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <div className="p-4 bg-gray-50 dark:bg-black/10 rounded-lg">
                 <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">Mevcut Plan:</p>
                 <div className="flex items-center justify-between">
-                  <span className="text-base text-gray-700 dark:text-gray-300">
+                  <span className="text-base text-gray-700 dark:text-white/70">
                     {subscription?.plan_id === "premium-yearly" ? "Yıllık Premium" : "Aylık Premium"}
                   </span>
                   <Badge variant="outline">
@@ -453,7 +453,7 @@ export default function PremiumPage() {
                 </div>
               </div>
             </div>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
+            <p className="text-sm text-gray-600 dark:text-white/60 mt-4">
               Plan değişikliği hemen gerçekleşecek ve yeni ödeme döngüsü başlayacaktır.
             </p>
           </div>
@@ -461,7 +461,7 @@ export default function PremiumPage() {
             <Button
               variant="outline"
               onClick={() => setShowConfirmDialog(false)}
-              className="border-gray-300 dark:border-gray-700"
+              className="border-gray-300 dark:border-white/10"
             >
               İptal
             </Button>

--- a/app/uygulama/raporlar/page.tsx
+++ b/app/uygulama/raporlar/page.tsx
@@ -500,12 +500,12 @@ export default function RaporlarPage() {
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-150px)] p-8">
         <div className="text-center max-w-md">
           <div className="mb-6">
-            <div className="mx-auto w-20 h-20 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center">
-              <BarChart3 className="h-10 w-10 text-gray-400 dark:text-gray-500" />
+            <div className="mx-auto w-20 h-20 bg-gray-100 dark:bg-black/10 rounded-full flex items-center justify-center">
+              <BarChart3 className="h-10 w-10 text-gray-400 dark:text-white/60" />
             </div>
           </div>
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">Henüz Veri Yok</h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-6">
+          <p className="text-gray-600 dark:text-white/60 mb-6">
             Raporlarınızı görebilmek için önce kredi ekleyin ve ödemelerinizi kaydedin.
           </p>
           <Button onClick={() => router.push("/uygulama/krediler/kredi-ekle")} className="bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700">
@@ -623,7 +623,7 @@ export default function RaporlarPage() {
               </div>
               <div>
                 <CardTitle className="text-xl dark:text-white">Akıllı Filtreler</CardTitle>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Verilerinizi detaylı analiz edin</p>
+                <p className="text-sm text-gray-500 dark:text-white/60 mt-1">Verilerinizi detaylı analiz edin</p>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -658,12 +658,12 @@ export default function RaporlarPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
             {/* Search */}
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-white/60" />
               <Input
                 placeholder="Banka veya kredi türü ara..."
                 value={filters.searchTerm}
                 onChange={(e) => updateFilter("searchTerm", e.target.value)}
-                className="pl-10 h-11 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 focus:border-emerald-500 focus:ring-emerald-500 dark:text-white"
+                className="pl-10 h-11 bg-white dark:bg-black/10 border-gray-200 dark:border-white/10 focus:border-emerald-500 focus:ring-emerald-500 dark:text-white"
               />
             </div>
 
@@ -672,8 +672,8 @@ export default function RaporlarPage() {
               value={filters.dateRange.preset}
               onValueChange={(value) => updateFilter("dateRange", { ...filters.dateRange, preset: value })}
             >
-              <SelectTrigger className="h-11 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 dark:text-white">
-                <Calendar className="h-4 w-4 mr-2 text-gray-500 dark:text-gray-400" />
+              <SelectTrigger className="h-11 bg-white dark:bg-black/10 border-gray-200 dark:border-white/10 dark:text-white">
+                <Calendar className="h-4 w-4 mr-2 text-gray-500 dark:text-white/60" />
                 <SelectValue placeholder="Zaman dilimi" />
               </SelectTrigger>
               <SelectContent>
@@ -691,13 +691,13 @@ export default function RaporlarPage() {
               <PopoverTrigger asChild>
                 <Button
                   variant="outline"
-                  className="justify-start h-11 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 dark:text-white"
+                  className="justify-start h-11 bg-white dark:bg-black/10 border-gray-200 dark:border-white/10 dark:text-white"
                 >
-                  <Building2 className="h-4 w-4 mr-2 text-gray-500 dark:text-gray-400" />
+                  <Building2 className="h-4 w-4 mr-2 text-gray-500 dark:text-white/60" />
                   Bankalar {filters.banks.length > 0 && `(${filters.banks.length})`}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-80 p-4 dark:bg-gray-800 dark:border-gray-700">
+              <PopoverContent className="w-80 p-4 dark:bg-black/10 dark:border-white/10">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <Label className="font-medium dark:text-white">Banka Seçimi</Label>
@@ -723,7 +723,7 @@ export default function RaporlarPage() {
                             updateFilter("banks", newBanks)
                           }}
                         />
-                        <Label htmlFor={`bank-${bank}`} className="text-sm cursor-pointer flex-1 dark:text-gray-300">
+                        <Label htmlFor={`bank-${bank}`} className="text-sm cursor-pointer flex-1 dark:text-white/70">
                           {bank}
                         </Label>
                       </div>
@@ -734,7 +734,7 @@ export default function RaporlarPage() {
             </Popover>
 
             {/* Quick Stats */}
-            <div className="flex items-center justify-center gap-4 text-sm text-gray-600 dark:text-gray-300 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-lg px-4 py-2">
+            <div className="flex items-center justify-center gap-4 text-sm text-gray-600 dark:text-white/70 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-lg px-4 py-2">
               <div className="flex items-center gap-1">
                 <CreditCard className="h-4 w-4" />
                 <span>{filteredCredits.length} kredi</span>
@@ -749,7 +749,7 @@ export default function RaporlarPage() {
 
           {/* Advanced Filters */}
           {expandedFilters && (
-            <div className="border-t dark:border-gray-700 pt-6">
+            <div className="border-t dark:border-white/10 pt-6">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {/* Credit Type Filter */}
                 <div className="space-y-3">
@@ -767,7 +767,7 @@ export default function RaporlarPage() {
                             updateFilter("creditTypes", newTypes)
                           }}
                         />
-                        <Label htmlFor={`type-${type}`} className="text-sm cursor-pointer dark:text-gray-300">
+                        <Label htmlFor={`type-${type}`} className="text-sm cursor-pointer dark:text-white/70">
                           {type}
                         </Label>
                       </div>
@@ -789,7 +789,7 @@ export default function RaporlarPage() {
                           min: Number(e.target.value) || 0,
                         })
                       }
-                      className="flex-1 dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      className="flex-1 dark:bg-black/10 dark:border-white/10 dark:text-white"
                     />
                     <Minus className="h-4 w-4 text-gray-400" />
                     <Input
@@ -802,7 +802,7 @@ export default function RaporlarPage() {
                           max: Number(e.target.value) || 10000000,
                         })
                       }
-                      className="flex-1 dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      className="flex-1 dark:bg-black/10 dark:border-white/10 dark:text-white"
                     />
                   </div>
                 </div>
@@ -821,7 +821,7 @@ export default function RaporlarPage() {
                           min: Number(e.target.value) || 0,
                         })
                       }
-                      className="flex-1 dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      className="flex-1 dark:bg-black/10 dark:border-white/10 dark:text-white"
                     />
                     <Minus className="h-4 w-4 text-gray-400" />
                     <Input
@@ -834,7 +834,7 @@ export default function RaporlarPage() {
                           max: Number(e.target.value) || 50,
                         })
                       }
-                      className="flex-1 dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      className="flex-1 dark:bg-black/10 dark:border-white/10 dark:text-white"
                     />
                   </div>
                 </div>
@@ -846,48 +846,48 @@ export default function RaporlarPage() {
 
     
       {/* Premium Tabs */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-3 lg:grid-cols-6 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="overview"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Eye className="h-4 w-4" />
                 <span className="font-medium">Genel Bakış</span>
               </TabsTrigger>
               <TabsTrigger
                 value="trends"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <TrendingUp className="h-4 w-4" />
                 <span className="font-medium">Trendler</span>
               </TabsTrigger>
               <TabsTrigger
                 value="distribution"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <PieChart className="h-4 w-4" />
                 <span className="font-medium">Dağılım</span>
               </TabsTrigger>
               <TabsTrigger
                 value="performance"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Activity className="h-4 w-4" />
                 <span className="font-medium">Performans</span>
               </TabsTrigger>
               <TabsTrigger
                 value="analysis"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Target className="h-4 w-4" />
                 <span className="font-medium">Analiz</span>
               </TabsTrigger>
               <TabsTrigger
                 value="comparison"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Building2 className="h-4 w-4" />
                 <span className="font-medium">Karşılaştırma</span>
@@ -1081,7 +1081,7 @@ export default function RaporlarPage() {
                     </div>
                     Detaylı Trend Analizi
                   </CardTitle>
-                  <p className="text-gray-600 dark:text-gray-300">12 aylık ödeme performansı ve trend analizi</p>
+                  <p className="text-gray-600 dark:text-white/70">12 aylık ödeme performansı ve trend analizi</p>
                 </CardHeader>
                 <CardContent>
                   <ResponsiveContainer width="100%" height={400}>
@@ -1283,7 +1283,7 @@ export default function RaporlarPage() {
                     </div>
                     Faiz Oranı Analizi
                   </CardTitle>
-                  <p className="text-gray-600 dark:text-gray-300">
+                  <p className="text-gray-600 dark:text-white/70">
                     Kredilerinizin faiz oranları ve piyasa karşılaştırması
                   </p>
                 </CardHeader>
@@ -1328,7 +1328,7 @@ export default function RaporlarPage() {
                       {chartData.bankDistribution.slice(0, 5).map((bank, index) => (
                         <div
                           key={bank.name}
-                          className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-xl border dark:border-gray-700 shadow-sm"
+                          className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-xl border dark:border-white/10 shadow-sm"
                         >
                           <div className="flex items-center gap-4">
                             <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-sm font-bold text-white">
@@ -1338,13 +1338,13 @@ export default function RaporlarPage() {
                               <BankLogo bankName={bank.fullName || bank.name} logoUrl={bank.logoUrl} size="sm" />
                               <div>
                                 <div className="font-semibold text-gray-900 dark:text-white">{bank.name}</div>
-                                <div className="text-sm text-gray-500 dark:text-gray-400">{bank.count} kredi</div>
+                                <div className="text-sm text-gray-500 dark:text-white/60">{bank.count} kredi</div>
                               </div>
                             </div>
                           </div>
                           <div className="text-right">
                             <div className="font-bold text-lg dark:text-white">{formatCurrency(bank.value)}</div>
-                            <div className="text-sm text-gray-500 dark:text-gray-400">
+                            <div className="text-sm text-gray-500 dark:text-white/60">
                               Ort. %{bank.averageInterest.toFixed(1)} faiz
                             </div>
                           </div>

--- a/app/uygulama/risk-analizi/[id]/page.tsx
+++ b/app/uygulama/risk-analizi/[id]/page.tsx
@@ -150,7 +150,7 @@ const SectionCard: React.FC<{
   <Collapsible defaultOpen={defaultOpen}>
     <Card className="border-0 shadow-lg overflow-hidden">
       <CollapsibleTrigger className="w-full">
-        <CardHeader className="bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+        <CardHeader className="bg-gray-50 dark:bg-black/10/50 hover:bg-gray-100 dark:hover:bg-black/10 transition-colors">
           <div className="flex items-center justify-between">
             <div className="flex items-center">
               <span className={`p-2 bg-gradient-to-r ${iconGradient} text-white rounded-lg mr-4 shadow-lg`}>
@@ -159,7 +159,7 @@ const SectionCard: React.FC<{
               <div>
                 <CardTitle className="text-xl font-semibold text-gray-800 dark:text-gray-100">{title}</CardTitle>
                 {description && (
-                  <CardDescription className="text-sm text-gray-500 dark:text-gray-400">{description}</CardDescription>
+                  <CardDescription className="text-sm text-gray-500 dark:text-white/60">{description}</CardDescription>
                 )}
               </div>
             </div>
@@ -168,7 +168,7 @@ const SectionCard: React.FC<{
         </CardHeader>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <CardContent className="p-6 space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed">{children}</CardContent>
+        <CardContent className="p-6 space-y-4 text-gray-700 dark:text-white/70 leading-relaxed">{children}</CardContent>
       </CollapsibleContent>
     </Card>
   </Collapsible>
@@ -278,10 +278,10 @@ export default function RiskAnalysisDetailPage() {
           <FileText className="h-24 w-24 text-emerald-500 opacity-20" />
           <Loader2 className="absolute inset-0 m-auto h-12 w-12 animate-spin text-emerald-600" />
         </div>
-        <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-300">
+        <h2 className="text-2xl font-semibold text-gray-700 dark:text-white/70">
           Detaylı Risk Analiziniz Hazırlanıyor...
         </h2>
-        <p className="text-gray-500 dark:text-gray-400 max-w-md">
+        <p className="text-gray-500 dark:text-white/60 max-w-md">
           Finansal verileriniz ve kredi bilgileriniz Gemini AI kullanılarak kapsamlı bir şekilde değerlendiriliyor. Bu
           işlem birkaç saniye sürebilir.
         </p>
@@ -443,15 +443,15 @@ export default function RiskAnalysisDetailPage() {
       </div>
 
       {/* Modern Tabs */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-xl border border-gray-200 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-          <div className="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-1 p-1 h-auto">
               {["summary", "factors", "recommendations", "details", "outlook"].map((tab) => (
                 <TabsTrigger
                   key={tab}
                   value={tab}
-                  className="flex items-center justify-center gap-2 py-2.5 px-3 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-700 data-[state=active]:text-emerald-600 data-[state=active]:shadow-sm rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700/70 text-xs sm:text-sm"
+                  className="flex items-center justify-center gap-2 py-2.5 px-3 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-700 data-[state=active]:text-emerald-600 data-[state=active]:shadow-sm rounded-lg transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10/70 text-xs sm:text-sm"
                 >
                   {tab === "summary" && (
                     <>
@@ -522,7 +522,7 @@ export default function RiskAnalysisDetailPage() {
                     <strong className="font-medium">Açıklama:</strong> {analysisData.debtToIncomeRatio.explanation}
                   </p>
                   {analysisData.debtToIncomeRatio.benchmark && (
-                    <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-md text-sm space-y-1">
+                    <div className="p-3 bg-gray-100 dark:bg-black/10 rounded-md text-sm space-y-1">
                       <p>
                         <strong>İdeal Aralık:</strong> {analysisData.debtToIncomeRatio.benchmark.idealRange}
                       </p>
@@ -816,7 +816,7 @@ export default function RiskAnalysisDetailPage() {
               >
                 <p>{analysisData.creditHealthSummary}</p>
                 {analysisData.creditUtilization && (
-                  <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                  <div className="mt-3 pt-3 border-t border-gray-200 dark:border-white/10 space-y-2">
                     <div className="flex items-center">
                       <strong className="mr-2">Değerlendirme:</strong>
                       <Badge variant={analysisData.creditUtilization.assessment === "İyi" ? "default" : "outline"}>
@@ -1055,7 +1055,7 @@ export default function RiskAnalysisDetailPage() {
             <AlertDialogTitle>Risk Analizini Sil</AlertDialogTitle>
             <AlertDialogDescription>
               Bu risk analizini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.
-              <div className="mt-3 p-3 bg-gray-100 dark:bg-gray-800 rounded-lg text-sm">
+              <div className="mt-3 p-3 bg-gray-100 dark:bg-black/10 rounded-lg text-sm">
                 <strong>Tarih:</strong> {new Date(analysis.created_at).toLocaleDateString("tr-TR")}
                 <br />
                 <strong>Risk Skoru:</strong> {analysis.overall_risk_score || "Bilinmiyor"}

--- a/app/uygulama/risk-analizi/page.tsx
+++ b/app/uygulama/risk-analizi/page.tsx
@@ -454,7 +454,7 @@ export default function RiskAnaliziPage() {
         <Alert variant="destructive" className="shadow-md dark:bg-red-900/30 dark:border-red-700/50">
           <AlertTriangle className="h-4 w-4" />
           <ShadcnAlertTitle className="dark:text-white">Eksik Bilgi</ShadcnAlertTitle>
-          <ShadcnAlertDescription className="dark:text-gray-300">
+          <ShadcnAlertDescription className="dark:text-white/70">
             {initialDataError || "Risk analizi için finansal profilinizde en azından aylık gelir bilgisi bulunmalıdır."}
             <Button
               variant="link"
@@ -468,7 +468,7 @@ export default function RiskAnaliziPage() {
       )}
 
       {isAnalyzing && (
-        <Card className="shadow-lg dark:bg-gray-900 dark:border-gray-800">
+        <Card className="shadow-lg dark:bg-black/20 dark:border-white/10">
           <CardContent className="p-8 text-center">
             <div className="flex flex-col items-center gap-4">
               <RefreshCw className="h-16 w-16 animate-spin text-red-600" />
@@ -476,16 +476,16 @@ export default function RiskAnaliziPage() {
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
                   Kapsamlı Risk Analizi Hazırlanıyor
                 </h3>
-                <p className="text-gray-600 dark:text-gray-300">{totalFinancialInstruments} kredi analiz ediliyor...</p>
+                <p className="text-gray-600 dark:text-white/70">{totalFinancialInstruments} kredi analiz ediliyor...</p>
               </div>
               <div className="w-full max-w-md">
-                <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400 mb-1">
+                <div className="flex justify-between text-sm text-gray-500 dark:text-white/60 mb-1">
                   <span>İlerleme</span>
                   <span>{Math.round(analysisProgress)}%</span>
                 </div>
                 <Progress value={analysisProgress} className="h-2" />
               </div>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Krediler kapsamlı analiz yapılıyor</p>
+              <p className="text-sm text-gray-500 dark:text-white/60">Krediler kapsamlı analiz yapılıyor</p>
             </div>
           </CardContent>
         </Card>
@@ -495,7 +495,7 @@ export default function RiskAnaliziPage() {
         <Alert variant="destructive" className="shadow-md dark:bg-red-900/30 dark:border-red-700/50">
           <AlertTriangle className="h-4 w-4" />
           <ShadcnAlertTitle className="dark:text-white">Analiz Hatası</ShadcnAlertTitle>
-          <ShadcnAlertDescription className="dark:text-gray-300">{analysisError}</ShadcnAlertDescription>
+          <ShadcnAlertDescription className="dark:text-white/70">{analysisError}</ShadcnAlertDescription>
         </Alert>
       )}
 
@@ -536,41 +536,41 @@ export default function RiskAnaliziPage() {
             />
           </div>
 
-          <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden mt-6">
+          <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden mt-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+              <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
                 <TabsList className="grid grid-cols-2 sm:grid-cols-4 bg-transparent h-auto p-2 gap-2">
                   <TabsTrigger
                     value="tumAnalizler"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/70"
                   >
                     <ListChecks className="h-4 w-4" />
                     Tümü ({totalAnalysesCount})
                   </TabsTrigger>
                   <TabsTrigger
                     value="dusukRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/70"
                   >
                     <CheckCircle className="h-4 w-4" />
                     Düşük ({riskDistribution.low})
                   </TabsTrigger>
                   <TabsTrigger
                     value="ortaRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/70"
                   >
                     <Clock className="h-4 w-4" />
                     Orta ({riskDistribution.medium})
                   </TabsTrigger>
                   <TabsTrigger
                     value="yuksekRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10 dark:text-white/70"
                   >
                     <AlertTriangle className="h-4 w-4" />
                     Yüksek ({riskDistribution.high})
                   </TabsTrigger>
                 </TabsList>
               </div>
-              <div className="p-4 border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+              <div className="p-4 border-b border-gray-100 dark:border-white/10 bg-white dark:bg-black/20">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div className="flex gap-2">
                     <div className="relative">
@@ -586,7 +586,7 @@ export default function RiskAnaliziPage() {
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="outline"
-                          className="flex items-center gap-2 bg-transparent dark:text-gray-300 dark:border-gray-700"
+                          className="flex items-center gap-2 bg-transparent dark:text-white/70 dark:border-white/10"
                         >
                           <ArrowUpDown className="h-4 w-4" />
                           Sırala: {sortBy === "created_at" ? "Tarih" : "Risk Skoru"} (
@@ -601,12 +601,12 @@ export default function RiskAnaliziPage() {
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </div>
-                  <div className="flex border rounded-lg dark:border-gray-700">
+                  <div className="flex border rounded-lg dark:border-white/10">
                     <Button
                       variant={viewMode === "cards" ? "default" : "ghost"}
                       size="sm"
                       onClick={() => handleViewModeChange("cards")}
-                      className={`rounded-r-none ${viewMode === "cards" ? "bg-gradient-to-r from-orange-600 to-amber-700 hover:from-orange-700 hover:to-amber-800 text-white" : "dark:text-gray-300"}`}
+                      className={`rounded-r-none ${viewMode === "cards" ? "bg-gradient-to-r from-orange-600 to-amber-700 hover:from-orange-700 hover:to-amber-800 text-white" : "dark:text-white/70"}`}
                     >
                       <BsFillGrid3X3GapFill className="h-4 w-4" />
                     </Button>
@@ -614,23 +614,23 @@ export default function RiskAnaliziPage() {
                       variant={viewMode === "table" ? "default" : "ghost"}
                       size="sm"
                       onClick={() => handleViewModeChange("table")}
-                      className={`rounded-l-none ${viewMode === "table" ? "bg-gradient-to-r from-orange-600 to-amber-700 hover:from-orange-700 hover:to-amber-800 text-white" : "dark:text-gray-300"}`}
+                      className={`rounded-l-none ${viewMode === "table" ? "bg-gradient-to-r from-orange-600 to-amber-700 hover:from-orange-700 hover:to-amber-800 text-white" : "dark:text-white/70"}`}
                     >
                       <List className="h-4 w-4" />
                     </Button>
                   </div>
                 </div>
               </div>
-              <div className="p-6 dark:bg-gray-900">
+              <div className="p-6 dark:bg-black/20">
                 {currentPastAnalyses.length === 0 && (
                   <div className="text-center py-12">
-                    <div className="mx-auto w-24 h-24 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mb-4">
-                      <History className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+                    <div className="mx-auto w-24 h-24 bg-gray-100 dark:bg-black/10 rounded-full flex items-center justify-center mb-4">
+                      <History className="h-12 w-12 text-gray-400 dark:text-white/60" />
                     </div>
                     <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
                       {totalAnalysesCount === 0 ? "Henüz Risk Analizi Yok" : "Bu Filtreye Uygun Analiz Bulunamadı"}
                     </h3>
-                    <p className="text-gray-500 dark:text-gray-400 mb-6 max-w-md mx-auto">
+                    <p className="text-gray-500 dark:text-white/60 mb-6 max-w-md mx-auto">
                       {totalAnalysesCount === 0
                         ? "İlk risk analizinizi oluşturmak için yukarıdaki 'Kapsamlı Analizi Başlat' butonuna tıklayın."
                         : "Farklı filtreler deneyebilir veya arama terimini değiştirebilirsiniz."}
@@ -654,7 +654,7 @@ export default function RiskAnaliziPage() {
                       {currentPastAnalyses.map((pa) => (
                         <Card
                           key={pa.id}
-                          className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-gray-700 dark:bg-gray-800 cursor-pointer"
+                          className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-white/10 dark:bg-black/10 cursor-pointer"
                           onClick={() => viewAnalysisDetails(pa.id)}
                         >
                           <CardHeader className="pb-3">
@@ -669,20 +669,20 @@ export default function RiskAnaliziPage() {
                           </CardHeader>
                           <CardContent className="space-y-3">
                             <div>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">Risk Skoru</p>
+                              <p className="text-sm text-gray-500 dark:text-white/60">Risk Skoru</p>
                               <p className="text-lg font-semibold text-gray-900 dark:text-white">
                                 {pa.overall_risk_score || "N/A"}
                               </p>
                             </div>
                             <div>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">Borç/Gelir Oranı</p>
+                              <p className="text-sm text-gray-500 dark:text-white/60">Borç/Gelir Oranı</p>
                               <p className="text-lg font-semibold text-gray-900 dark:text-white">
                                 {pa.debt_to_income_ratio || "N/A"}
                               </p>
                             </div>
                             <div>
                               <div className="flex justify-between text-sm mb-2">
-                                <span className="text-gray-500 dark:text-gray-400">Risk Seviyesi</span>
+                                <span className="text-gray-500 dark:text-white/60">Risk Seviyesi</span>
                                 <span className="font-medium text-gray-900 dark:text-white">
                                   {getRiskBadgeText(pa.overall_risk_color)}
                                 </span>
@@ -696,7 +696,7 @@ export default function RiskAnaliziPage() {
                               <Button
                                 size="sm"
                                 variant="outline"
-                                className="flex-1 bg-transparent dark:text-gray-300 dark:border-gray-700 dark:hover:bg-gray-700"
+                                className="flex-1 bg-transparent dark:text-white/70 dark:border-white/10 dark:hover:bg-black/10"
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   viewAnalysisDetails(pa.id)
@@ -708,7 +708,7 @@ export default function RiskAnaliziPage() {
                               <Button
                                 size="sm"
                                 variant="outline"
-                                className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30 bg-transparent dark:border-gray-700"
+                                className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30 bg-transparent dark:border-white/10"
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   openDeleteDialog(pa)
@@ -738,9 +738,9 @@ export default function RiskAnaliziPage() {
                     <div className="overflow-x-auto">
                       <Table>
                         <TableHeader>
-                          <TableRow className="bg-white dark:bg-gray-900 dark:border-gray-800">
+                          <TableRow className="bg-white dark:bg-black/20 dark:border-white/10">
                             <TableHead
-                              className="dark:text-gray-300 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
+                              className="dark:text-white/70 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
                               onClick={() => handleSort("created_at")}
                             >
                               <div className="flex items-center gap-1">
@@ -749,7 +749,7 @@ export default function RiskAnaliziPage() {
                               </div>
                             </TableHead>
                             <TableHead
-                              className="dark:text-gray-300 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
+                              className="dark:text-white/70 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
                               onClick={() => handleSort("overall_risk_score")}
                             >
                               <div className="flex items-center gap-1">
@@ -757,9 +757,9 @@ export default function RiskAnaliziPage() {
                                 <ArrowUpDown className="h-3 w-3" />
                               </div>
                             </TableHead>
-                            <TableHead className="dark:text-gray-300">Risk Seviyesi</TableHead>
+                            <TableHead className="dark:text-white/70">Risk Seviyesi</TableHead>
                             <TableHead
-                              className="dark:text-gray-300 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
+                              className="dark:text-white/70 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
                               onClick={() => handleSort("debt_to_income_ratio")}
                             >
                               <div className="flex items-center gap-1">
@@ -768,7 +768,7 @@ export default function RiskAnaliziPage() {
                               </div>
                             </TableHead>
                             <TableHead
-                              className="dark:text-gray-300 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
+                              className="dark:text-white/70 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
                               onClick={() => handleSort("monthly_income")}
                             >
                               <div className="flex items-center gap-1">
@@ -777,7 +777,7 @@ export default function RiskAnaliziPage() {
                               </div>
                             </TableHead>
                             <TableHead
-                              className="dark:text-gray-300 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
+                              className="dark:text-white/70 cursor-pointer hover:text-red-600 dark:hover:text-red-400"
                               onClick={() => handleSort("total_debt_amount")}
                             >
                               <div className="flex items-center gap-1">
@@ -785,30 +785,30 @@ export default function RiskAnaliziPage() {
                                 <ArrowUpDown className="h-3 w-3" />
                               </div>
                             </TableHead>
-                            <TableHead className="text-right dark:text-gray-300">İşlemler</TableHead>
+                            <TableHead className="text-right dark:text-white/70">İşlemler</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
                           {currentPastAnalyses.map((pa) => (
                             <TableRow
                               key={pa.id}
-                              className="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer dark:border-gray-800"
+                              className="hover:bg-gray-50 dark:hover:bg-black/10 cursor-pointer dark:border-white/10"
                               onClick={() => viewAnalysisDetails(pa.id)}
                             >
-                              <TableCell className="font-medium dark:text-gray-300">
+                              <TableCell className="font-medium dark:text-white/70">
                                 {format(new Date(pa.created_at), "dd.MM.yyyy HH:mm")}
                               </TableCell>
-                              <TableCell className="dark:text-gray-300">{pa.overall_risk_score || "N/A"}</TableCell>
+                              <TableCell className="dark:text-white/70">{pa.overall_risk_score || "N/A"}</TableCell>
                               <TableCell>
                                 <Badge className={getRiskBadgeClass(pa.overall_risk_color)}>
                                   {getRiskBadgeText(pa.overall_risk_color)}
                                 </Badge>
                               </TableCell>
-                              <TableCell className="dark:text-gray-300">{pa.debt_to_income_ratio || "N/A"}</TableCell>
-                              <TableCell className="dark:text-gray-300">
+                              <TableCell className="dark:text-white/70">{pa.debt_to_income_ratio || "N/A"}</TableCell>
+                              <TableCell className="dark:text-white/70">
                                 {formatCurrency(pa.monthly_income || 0)}
                               </TableCell>
-                              <TableCell className="dark:text-gray-300">
+                              <TableCell className="dark:text-white/70">
                                 {formatCurrency(pa.total_debt_amount || 0)}
                               </TableCell>
                               <TableCell className="text-right">
@@ -816,7 +816,7 @@ export default function RiskAnaliziPage() {
                                   <DropdownMenuTrigger asChild>
                                     <Button
                                       variant="ghost"
-                                      className="h-8 w-8 p-0 dark:text-gray-300"
+                                      className="h-8 w-8 p-0 dark:text-white/70"
                                       onClick={(e) => e.stopPropagation()}
                                     >
                                       <MoreHorizontal className="h-4 w-4" />

--- a/app/uygulama/sifrelerim/page.tsx
+++ b/app/uygulama/sifrelerim/page.tsx
@@ -442,7 +442,7 @@ export default function BankaciSifrelerimPage() {
     return (
       <div className="flex flex-col gap-4 md:gap-6 items-center justify-center min-h-[calc(100vh-150px)]">
         <Loader2 className="h-12 w-12 animate-spin text-emerald-600" />
-        <p className="text-lg text-gray-600 dark:text-gray-300">Veriler yükleniyor...</p>
+        <p className="text-lg text-gray-600 dark:text-white/70">Veriler yükleniyor...</p>
       </div>
     )
   }
@@ -528,13 +528,13 @@ export default function BankaciSifrelerimPage() {
       </div>
 
       {/* Modern Tabs */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div className="bg-white dark:bg-black/20 rounded-2xl shadow-sm border border-gray-100 dark:border-white/10 overflow-hidden">
         <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-          <div className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/50">
+          <div className="border-b border-gray-100 dark:border-white/10 bg-gray-50/50 dark:bg-black/10/50">
             <TabsList className="grid grid-cols-5 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="tumSifreler"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Key className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Tüm Şifreler</span>
@@ -542,7 +542,7 @@ export default function BankaciSifrelerimPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="internetBankaciligi"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Globe className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">İnternet</span>
@@ -550,7 +550,7 @@ export default function BankaciSifrelerimPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="mobilBankaciligi"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Smartphone className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Mobil</span>
@@ -558,7 +558,7 @@ export default function BankaciSifrelerimPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="telefonBankaciligi"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Phone className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Telefon</span>
@@ -566,7 +566,7 @@ export default function BankaciSifrelerimPage() {
               </TabsTrigger>
               <TabsTrigger
                 value="diger"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-black/10"
               >
                 <Settings className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Diğer</span>
@@ -576,7 +576,7 @@ export default function BankaciSifrelerimPage() {
           </div>
 
           {/* Search, Sort and View Toggle */}
-          <div className="p-4 border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+          <div className="p-4 border-b border-gray-100 dark:border-white/10 bg-white dark:bg-black/20">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div className="flex gap-2">
                 <div className="relative">
@@ -596,16 +596,16 @@ export default function BankaciSifrelerimPage() {
                       {sortOrder === "asc" ? "Artan" : "Azalan"})
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="dark:bg-gray-800 dark:border-gray-700">
+                  <DropdownMenuContent align="start" className="dark:bg-black/10 dark:border-white/10">
                     <DropdownMenuItem
                       onClick={() => handleSort("sonKullanim")}
-                      className="dark:text-white dark:hover:bg-gray-700"
+                      className="dark:text-white dark:hover:bg-black/10"
                     >
                       Son Kullanıma Göre
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={() => handleSort("bankaAdi")}
-                      className="dark:text-white dark:hover:bg-gray-700"
+                      className="dark:text-white dark:hover:bg-black/10"
                     >
                       Banka Adına Göre
                     </DropdownMenuItem>
@@ -639,9 +639,9 @@ export default function BankaciSifrelerimPage() {
           <div className="p-6">
             {currentItems.length === 0 && !loadingData && (
               <div className="text-center py-10">
-                <Lock className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+                <Lock className="mx-auto h-12 w-12 text-gray-400 dark:text-white/60" />
                 <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">Şifre Bulunamadı</h3>
-                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-sm text-gray-500 dark:text-white/60">
                   {activeTab === "tumSifreler" ? "Hiç şifre eklenmemiş." : "Bu filtreye uygun şifre bulunamadı."}
                 </p>
                 <div className="mt-6">
@@ -666,7 +666,7 @@ export default function BankaciSifrelerimPage() {
                     return (
                       <Card
                         key={credential.id}
-                        className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-gray-700 overflow-hidden"
+                        className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-white/10 overflow-hidden"
                       >
                         <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700">
                           <div className="flex items-center justify-between">
@@ -700,14 +700,14 @@ export default function BankaciSifrelerimPage() {
                         <CardContent className="space-y-5 pt-4">
                           <div className="grid grid-cols-1 gap-4">
                             <div>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">Şifre Adı</p>
+                              <p className="text-sm text-gray-500 dark:text-white/60">Şifre Adı</p>
                               <p className="text-lg font-semibold text-gray-900 dark:text-white">
                                 {credential.credential_name}
                               </p>
                             </div>
                             {credential.username && (
                               <div>
-                                <p className="text-sm text-gray-500 dark:text-gray-400">Kullanıcı Adı</p>
+                                <p className="text-sm text-gray-500 dark:text-white/60">Kullanıcı Adı</p>
                                 <p className="text-lg font-semibold text-gray-900 dark:text-white">
                                   {credential.username}
                                 </p>
@@ -716,7 +716,7 @@ export default function BankaciSifrelerimPage() {
                           </div>
 
                           <div className="flex items-center gap-2">
-                            <span className="text-sm text-gray-500 dark:text-gray-400">Şifre:</span>
+                            <span className="text-sm text-gray-500 dark:text-white/60">Şifre:</span>
                             <PasswordDisplay
                               credential={credential}
                               isVisible={isPasswordVisible}
@@ -728,7 +728,7 @@ export default function BankaciSifrelerimPage() {
 
                           <div className="grid grid-cols-2 gap-4 text-sm">
                             <div>
-                              <p className="text-gray-500 dark:text-gray-400">Eklendi</p>
+                              <p className="text-gray-500 dark:text-white/60">Eklendi</p>
                               <p className="font-medium text-gray-900 dark:text-white">
                                 {formatDistanceToNow(new Date(credential.created_at), {
                                   addSuffix: true,
@@ -737,7 +737,7 @@ export default function BankaciSifrelerimPage() {
                               </p>
                             </div>
                             <div>
-                              <p className="text-gray-500 dark:text-gray-400">Son Kullanım</p>
+                              <p className="text-gray-500 dark:text-white/60">Son Kullanım</p>
                               <p className="font-medium text-gray-900 dark:text-white">
                                 {credential.last_used_date
                                   ? formatDistanceToNow(new Date(credential.last_used_date), {
@@ -802,9 +802,9 @@ export default function BankaciSifrelerimPage() {
                 <div className="overflow-x-auto">
                   <Table>
                     <TableHeader>
-                      <TableRow className="bg-white dark:bg-gray-900">
+                      <TableRow className="bg-white dark:bg-black/20">
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("bankaAdi")}
                         >
                           <div className="flex items-center gap-1">
@@ -813,7 +813,7 @@ export default function BankaciSifrelerimPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("tur")}
                         >
                           <div className="flex items-center gap-1">
@@ -822,7 +822,7 @@ export default function BankaciSifrelerimPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("sifreAdi")}
                         >
                           <div className="flex items-center gap-1">
@@ -831,7 +831,7 @@ export default function BankaciSifrelerimPage() {
                           </div>
                         </TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("kullaniciAdi")}
                         >
                           <div className="flex items-center gap-1">
@@ -839,9 +839,9 @@ export default function BankaciSifrelerimPage() {
                             <ArrowUpDown className="h-3 w-3" />
                           </div>
                         </TableHead>
-                        <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Şifre</TableHead>
+                        <TableHead className="font-semibold text-gray-700 dark:text-white/70">Şifre</TableHead>
                         <TableHead
-                          className="font-semibold text-gray-700 dark:text-gray-300 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
+                          className="font-semibold text-gray-700 dark:text-white/70 cursor-pointer hover:text-emerald-600 dark:hover:text-emerald-400"
                           onClick={() => handleSort("sonKullanim")}
                         >
                           <div className="flex items-center gap-1">
@@ -849,8 +849,8 @@ export default function BankaciSifrelerimPage() {
                             <ArrowUpDown className="h-3 w-3" />
                           </div>
                         </TableHead>
-                        <TableHead className="font-semibold text-gray-700 dark:text-gray-300">Durum</TableHead>
-                        <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-gray-300">
+                        <TableHead className="font-semibold text-gray-700 dark:text-white/70">Durum</TableHead>
+                        <TableHead className="w-[50px] text-right font-semibold text-gray-700 dark:text-white/70">
                           İşlemler
                         </TableHead>
                       </TableRow>
@@ -863,8 +863,8 @@ export default function BankaciSifrelerimPage() {
                         return (
                           <TableRow
                             key={credential.id}
-                            className={`hover:bg-emerald-50 dark:hover:bg-gray-800 transition-colors duration-150 ease-in-out ${
-                              index % 2 === 0 ? "bg-white dark:bg-gray-900" : "bg-gray-50/50 dark:bg-gray-800/50"
+                            className={`hover:bg-emerald-50 dark:hover:bg-black/10 transition-colors duration-150 ease-in-out ${
+                              index % 2 === 0 ? "bg-white dark:bg-black/20" : "bg-gray-50/50 dark:bg-black/10/50"
                             }`}
                           >
                             <TableCell>
@@ -873,7 +873,7 @@ export default function BankaciSifrelerimPage() {
                                   bankName={credential.bank_name || "Bilinmeyen Banka"}
                                   logoUrl={credential.bank_logo_url ?? undefined}
                                   size="md"
-                                  className="ring-1 ring-emerald-200 dark:ring-emerald-700 bg-white dark:bg-gray-800"
+                                  className="ring-1 ring-emerald-200 dark:ring-emerald-700 bg-white dark:bg-black/10"
                                 />
                                 <div>
                                   <span className="font-medium text-gray-900 dark:text-white block">
@@ -882,7 +882,7 @@ export default function BankaciSifrelerimPage() {
                                 </div>
                               </div>
                             </TableCell>
-                            <TableCell className="text-gray-600 dark:text-gray-300">
+                            <TableCell className="text-gray-600 dark:text-white/70">
                               <div className="flex items-center gap-2">
                                 <TypeIcon className="h-4 w-4" />
                                 {credentialTypeLabels[credential.credential_type]}
@@ -891,7 +891,7 @@ export default function BankaciSifrelerimPage() {
                             <TableCell className="font-semibold text-gray-900 dark:text-white">
                               {credential.credential_name}
                             </TableCell>
-                            <TableCell className="text-gray-600 dark:text-gray-300">
+                            <TableCell className="text-gray-600 dark:text-white/70">
                               {credential.username || "-"}
                             </TableCell>
                             <TableCell>
@@ -903,7 +903,7 @@ export default function BankaciSifrelerimPage() {
                                 isCopied={copiedPasswords.has(credential.id)}
                               />
                             </TableCell>
-                            <TableCell className="text-gray-600 dark:text-gray-300">
+                            <TableCell className="text-gray-600 dark:text-white/70">
                               {credential.last_used_date
                                 ? formatDistanceToNow(new Date(credential.last_used_date), {
                                     addSuffix: true,
@@ -1000,19 +1000,19 @@ export default function BankaciSifrelerimPage() {
 
       {/* Update Password Dialog */}
       <AlertDialog open={showUpdatePasswordDialog} onOpenChange={setShowUpdatePasswordDialog}>
-        <AlertDialogContent className="dark:bg-gray-800 dark:border-gray-700">
+        <AlertDialogContent className="dark:bg-black/10 dark:border-white/10">
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2 dark:text-white">
               <Key className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
               Şifre Güncelle
             </AlertDialogTitle>
-            <AlertDialogDescription className="dark:text-gray-400">
+            <AlertDialogDescription className="dark:text-white/60">
               {credentialToUpdate && (
                 <div className="mb-4">
                   <p className="font-medium text-gray-900 dark:text-white">
                     {credentialToUpdate.bank_name} - {credentialToUpdate.credential_name}
                   </p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                  <p className="text-sm text-gray-600 dark:text-white/60">
                     Kullanıcı: {credentialToUpdate.username || "N/A"}
                   </p>
                 </div>
@@ -1021,7 +1021,7 @@ export default function BankaciSifrelerimPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="py-4">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">Yeni Şifre</label>
+            <label className="text-sm font-medium text-gray-700 dark:text-white/70 mb-2 block">Yeni Şifre</label>
             <Input
               type="password"
               placeholder="Yeni şifrenizi girin..."
@@ -1039,7 +1039,7 @@ export default function BankaciSifrelerimPage() {
                 setNewPassword("")
               }}
               disabled={isUpdatingPassword}
-              className="dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              className="dark:bg-gray-700 dark:text-white/70 dark:hover:bg-gray-600"
             >
               İptal
             </AlertDialogCancel>
@@ -1117,7 +1117,7 @@ function PasswordDisplay({
 
   return (
     <div className="flex items-center gap-2">
-      <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-sm font-mono max-w-[120px] truncate text-gray-900 dark:text-gray-100">
+      <code className="bg-gray-100 dark:bg-black/10 px-2 py-1 rounded text-sm font-mono max-w-[120px] truncate text-gray-900 dark:text-gray-100">
         {displayPassword()}
       </code>
       <div className="flex gap-1">


### PR DESCRIPTION
Updated dark theme styling across all /uygulama pages to match the landing page's glassmorphism design:

- Background: dark:bg-gray-950 → dark:bg-[#151515]
- Cards: dark:bg-gray-900/800 → dark:bg-black/20 with backdrop-blur
- Borders: dark:border-gray-700/800 → dark:border-white/10
- Text: dark:text-gray-300/400 → dark:text-white/70/60
- Hover states: Updated to use transparent black overlays

This creates a consistent, modern glassmorphism aesthetic across the entire application that matches the landing page experience.

Files updated:
- Layout and 21 page components
- Maintained gradient cards and existing functionality
- Light mode styling unchanged