### PR TITLE
feat: Remove all gray colors from dark mode, apply emerald/teal theme…

### DIFF
--- a/app/uygulama/ana-sayfa/page.tsx
+++ b/app/uygulama/ana-sayfa/page.tsx
@@ -653,7 +653,7 @@ export default function DashboardPage() {
         </CardContent>
       </Card>
 
-      <Card className="relative overflow-hidden border-0 bg-gradient-to-br from-slate-700 via-gray-800 to-zinc-900 dark:from-slate-800 dark:via-gray-900 dark:to-zinc-950 shadow-2xl dark:shadow-slate-900/20 rounded-2xl">
+      <Card className="relative overflow-hidden border-0 bg-gradient-to-br from-slate-700 via-gray-800 to-zinc-900 dark:from-emerald-900/30 dark:via-emerald-950 dark:to-zinc-950 shadow-2xl dark:shadow-slate-900/20 rounded-2xl">
         <div className="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full -translate-y-32 translate-x-32"></div>
         <div className="absolute bottom-0 left-0 w-48 h-48 bg-white/5 rounded-full translate-y-24 -translate-x-24"></div>
         <CardHeader className="relative">

--- a/app/uygulama/ayarlar/page.tsx
+++ b/app/uygulama/ayarlar/page.tsx
@@ -1149,7 +1149,7 @@ export default function AyarlarPage() {
                     <div className="py-4">
                       <div className="space-y-3">
                         <div className="p-4 bg-gray-50 dark:bg-black/10 rounded-lg">
-                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">Mevcut Abonelik:</p>
+                          <p className="text-sm font-medium text-gray-900 dark:text-white mb-2">Mevcut Abonelik:</p>
                           <div className="flex items-center justify-between">
                             <span className="text-base text-gray-700 dark:text-white/70">
                               {subscription?.plan_id === "premium-yearly" ? "Yıllık Premium" : "Aylık Premium"}
@@ -1734,7 +1734,7 @@ export default function AyarlarPage() {
                       </div>
                       <Switch checked={theme === "dark"} onCheckedChange={handleDarkModeToggle} />
                     </div>
-                    <Separator className="dark:bg-gray-700" />
+                    <Separator className="dark:bg-white/10" />
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium dark:text-white">Kompakt Görünüm</p>
@@ -1742,7 +1742,7 @@ export default function AyarlarPage() {
                       </div>
                       <Switch checked={compactView} onCheckedChange={handleCompactViewToggle} />
                     </div>
-                    <Separator className="dark:bg-gray-700" />
+                    <Separator className="dark:bg-white/10" />
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium dark:text-white">Animasyonlar</p>

--- a/app/uygulama/bildirimler/page.tsx
+++ b/app/uygulama/bildirimler/page.tsx
@@ -491,7 +491,7 @@ export default function BildirimlerPage() {
                                 <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></div>
                               )}
                               <Badge
-                                className={`${!notification.is_read ? "bg-emerald-500 text-white" : "bg-gray-100 dark:bg-black/10 text-gray-600 dark:text-white/70"} text-xs px-2 py-1`}
+                                className={`${!notification.is_read ? "bg-emerald-500 text-white" : "bg-gray-100 dark:bg-black/10 text-gray-600 dark:text-white/60"} text-xs px-2 py-1`}
                               >
                                 {notification.is_read ? "Okundu" : "Yeni"}
                               </Badge>

--- a/app/uygulama/kredi-detay/[id]/page.tsx
+++ b/app/uygulama/kredi-detay/[id]/page.tsx
@@ -791,7 +791,7 @@ export default function KrediDetayPage() {
                 <div className="grid md:grid-cols-2 gap-6">
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <CreditCard className="h-5 w-5 text-teal-600" />
                         Kredi Bilgileri
                       </CardTitle>
@@ -800,17 +800,17 @@ export default function KrediDetayPage() {
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Kredi Kodu</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">{krediDetay.credit_code}</p>
+                          <p className="font-medium text-gray-900 dark:text-white">{krediDetay.credit_code}</p>
                         </div>
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Hesap No</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                          <p className="font-medium text-gray-900 dark:text-white">
                             {krediDetay.account_number || "N/A"}
                           </p>
                         </div>
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Başlangıç Tutarı</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                          <p className="font-medium text-gray-900 dark:text-white">
                             {formatCurrency(krediDetay.initial_amount)}
                           </p>
                         </div>
@@ -822,19 +822,19 @@ export default function KrediDetayPage() {
                         </div>
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Başlangıç Tarihi</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                          <p className="font-medium text-gray-900 dark:text-white">
                             {new Date(krediDetay.start_date).toLocaleDateString("tr-TR")}
                           </p>
                         </div>
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Bitiş Tarihi</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                          <p className="font-medium text-gray-900 dark:text-white">
                             {new Date(krediDetay.end_date).toLocaleDateString("tr-TR")}
                           </p>
                         </div>
                         <div>
                           <p className="text-sm text-gray-500 dark:text-white/60">Teminat</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                          <p className="font-medium text-gray-900 dark:text-white">
                             {krediDetay.collateral || "N/A"}
                           </p>
                         </div>
@@ -850,7 +850,7 @@ export default function KrediDetayPage() {
 
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <Building className="h-5 w-5 text-teal-600" />
                         Banka Bilgileri
                       </CardTitle>
@@ -863,7 +863,7 @@ export default function KrediDetayPage() {
                           size="md"
                         />
                         <div>
-                          <p className="font-semibold text-gray-900 dark:text-gray-100">
+                          <p className="font-semibold text-gray-900 dark:text-white">
                             {krediDetay.banks?.name || "N/A"}
                           </p>
                           <p className="text-sm text-gray-500 dark:text-white/60">{krediDetay.branch_name || "N/A"}</p>
@@ -940,7 +940,7 @@ export default function KrediDetayPage() {
               <div className="space-y-6">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Ödeme Planı</h3>
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Ödeme Planı</h3>
                     <p className="text-sm text-gray-600 dark:text-white/60">
                       Toplam {odemePlani.length} taksit • Sayfa {currentPage} / {totalPages}
                     </p>
@@ -978,7 +978,7 @@ export default function KrediDetayPage() {
                         return (
                           <div
                             key={taksit.id}
-                            className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
+                            className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-white/20 hover:shadow-sm transition-all"
                           >
                             <div className="flex items-center gap-4">
                               <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shadow-lg">
@@ -987,7 +987,7 @@ export default function KrediDetayPage() {
 
                               <div>
                                 <div className="flex items-center gap-3">
-                                  <span className="font-semibold text-gray-900 dark:text-gray-100">
+                                  <span className="font-semibold text-gray-900 dark:text-white">
                                     Taksit #{taksit.installment_number}
                                   </span>
                                 </div>
@@ -1003,7 +1003,7 @@ export default function KrediDetayPage() {
 
                             <div className="flex items-center gap-4">
                               <div className="text-right">
-                                <div className="font-bold text-gray-900 dark:text-gray-100 text-lg">
+                                <div className="font-bold text-gray-900 dark:text-white text-lg">
                                   {formatCurrency(taksit.total_payment)}
                                 </div>
                                 <div className="text-xs text-gray-500 dark:text-white/60">
@@ -1113,8 +1113,8 @@ export default function KrediDetayPage() {
                   </>
                 ) : (
                   <div className="text-center py-12 text-gray-500 dark:text-white/60">
-                    <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
-                    <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Ödeme Planı Bulunamadı</h3>
+                    <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-white/40" />
+                    <h3 className="font-medium text-gray-900 dark:text-white mb-2">Ödeme Planı Bulunamadı</h3>
                     <p className="text-sm">Bu kredi için ödeme planı bulunmuyor</p>
                   </div>
                 )}
@@ -1126,7 +1126,7 @@ export default function KrediDetayPage() {
               <div className="space-y-6">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Ödeme Geçmişi</h3>
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Ödeme Geçmişi</h3>
                     <p className="text-sm text-gray-600 dark:text-white/60">
                       Toplam {odemeGecmisi.length} ödeme • Sayfa {currentPageHistory} / {totalHistoryPages}
                     </p>
@@ -1144,7 +1144,7 @@ export default function KrediDetayPage() {
                       {currentHistoryItems.map((odeme, index) => (
                         <div
                           key={odeme.id}
-                          className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
+                          className="flex items-center justify-between p-4 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-xl hover:border-gray-300 dark:hover:border-white/20 hover:shadow-sm transition-all"
                         >
                           <div className="flex items-center gap-4">
                             <div className="bg-gradient-to-br from-emerald-500 to-teal-600 p-3 rounded-full shadow-lg">
@@ -1153,7 +1153,7 @@ export default function KrediDetayPage() {
 
                             <div>
                               <div className="flex items-center gap-3">
-                                <span className="font-semibold text-gray-900 dark:text-gray-100">
+                                <span className="font-semibold text-gray-900 dark:text-white">
                                   Ödeme #{startIndexHistory + index + 1}
                                 </span>
                               </div>
@@ -1413,8 +1413,8 @@ export default function KrediDetayPage() {
                   </>
                 ) : (
                   <div className="text-center py-12 text-gray-500 dark:text-white/60">
-                    <History className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
-                    <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Ödeme Geçmişi Bulunamadı</h3>
+                    <History className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-white/40" />
+                    <h3 className="font-medium text-gray-900 dark:text-white mb-2">Ödeme Geçmişi Bulunamadı</h3>
                     <p className="text-sm">Bu kredi için henüz ödeme yapılmamış</p>
                   </div>
                 )}
@@ -1427,7 +1427,7 @@ export default function KrediDetayPage() {
                 <div className="grid md:grid-cols-2 gap-6">
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <TrendingUp className="h-5 w-5 text-teal-600" />
                         Borç Azalış Grafiği
                       </CardTitle>
@@ -1489,7 +1489,7 @@ export default function KrediDetayPage() {
 
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <BarChart3 className="h-5 w-5 text-teal-600" />
                         Faiz/Ana Para Dağılımı
                       </CardTitle>
@@ -1543,7 +1543,7 @@ export default function KrediDetayPage() {
                           <div className="flex items-center gap-3">
                             <div className="w-4 h-4 rounded-full bg-teal-600"></div>
                             <div>
-                              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Ana Para</p>
+                              <p className="text-sm font-medium text-gray-900 dark:text-white">Ana Para</p>
                               <p className="text-lg font-bold text-teal-600">
                                 {formatCurrency(
                                   faizAnaParaDagilimi.find((item) => item.name === "Ana Para")?.value || 0,
@@ -1556,7 +1556,7 @@ export default function KrediDetayPage() {
                           <div className="flex items-center gap-3">
                             <div className="w-4 h-4 rounded-full bg-emerald-600"></div>
                             <div>
-                              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Faiz</p>
+                              <p className="text-sm font-medium text-gray-900 dark:text-white">Faiz</p>
                               <p className="text-lg font-bold text-emerald-600">
                                 {formatCurrency(faizAnaParaDagilimi.find((item) => item.name === "Faiz")?.value || 0)}
                               </p>
@@ -1572,7 +1572,7 @@ export default function KrediDetayPage() {
                 <div className="grid md:grid-cols-2 gap-6">
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <Calendar className="h-5 w-5 text-teal-600" />
                         Aylık Ödeme Trendi
                       </CardTitle>
@@ -1624,7 +1624,7 @@ export default function KrediDetayPage() {
 
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                      <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
                         <Target className="h-5 w-5 text-teal-600" />
                         Ödeme İlerlemesi
                       </CardTitle>
@@ -1640,7 +1640,7 @@ export default function KrediDetayPage() {
                             stroke="currentColor"
                             strokeWidth="8"
                             fill="transparent"
-                            className="text-gray-200 dark:text-gray-700"
+                            className="text-gray-200 dark:text-white/30"
                           />
                           <circle
                             cx="50"
@@ -1663,7 +1663,7 @@ export default function KrediDetayPage() {
                       </div>
                       <div className="text-center">
                         <p className="text-sm text-gray-600 dark:text-white/60 mb-2">Tamamlanan Ödeme</p>
-                        <p className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                        <p className="text-lg font-semibold text-gray-900 dark:text-white">
                           {(krediDetay?.total_installments || 0) - (krediDetay?.remaining_installments || 0)} /{" "}
                           {krediDetay?.total_installments || 0} Taksit
                         </p>
@@ -1680,7 +1680,7 @@ export default function KrediDetayPage() {
                 <div className="grid md:grid-cols-2 gap-6">
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="text-gray-900 dark:text-gray-100">Bildirim Ayarları</CardTitle>
+                      <CardTitle className="text-gray-900 dark:text-white">Bildirim Ayarları</CardTitle>
                       <CardDescription className="dark:text-white/60">
                         Bu kredi için bildirim tercihleriniz
                       </CardDescription>
@@ -1688,7 +1688,7 @@ export default function KrediDetayPage() {
                     <CardContent className="space-y-4">
                       <div className="flex items-center justify-between">
                         <div>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">Ödeme Hatırlatması</p>
+                          <p className="font-medium text-gray-900 dark:text-white">Ödeme Hatırlatması</p>
                           <p className="text-sm text-gray-500 dark:text-white/60">
                             Ödeme tarihi yaklaştığında bildirim al
                           </p>
@@ -1697,7 +1697,7 @@ export default function KrediDetayPage() {
                       </div>
                       <div className="flex items-center justify-between">
                         <div>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">Faiz Oranı Değişikliği</p>
+                          <p className="font-medium text-gray-900 dark:text-white">Faiz Oranı Değişikliği</p>
                           <p className="text-sm text-gray-500 dark:text-white/60">
                             Faiz oranı değiştiğinde bildirim al
                           </p>
@@ -1706,7 +1706,7 @@ export default function KrediDetayPage() {
                       </div>
                       <div className="flex items-center justify-between">
                         <div>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">Aylık Rapor</p>
+                          <p className="font-medium text-gray-900 dark:text-white">Aylık Rapor</p>
                           <p className="text-sm text-gray-500 dark:text-white/60">Aylık kredi raporu gönder</p>
                         </div>
                         <Switch />
@@ -1716,7 +1716,7 @@ export default function KrediDetayPage() {
 
                   <Card className="shadow-sm border-gray-200 dark:border-white/10 dark:bg-black/20">
                     <CardHeader>
-                      <CardTitle className="text-gray-900 dark:text-gray-100">Hızlı İşlemler</CardTitle>
+                      <CardTitle className="text-gray-900 dark:text-white">Hızlı İşlemler</CardTitle>
                       <CardDescription className="dark:text-white/60">
                         Bu kredi için yapabileceğiniz işlemler
                       </CardDescription>

--- a/app/uygulama/kredi-duzenle/[id]/page.tsx
+++ b/app/uygulama/kredi-duzenle/[id]/page.tsx
@@ -799,7 +799,7 @@ export default function KrediDuzenlePage() {
                       </div>
                     ) : paymentPlans.length === 0 ? (
                       <div className="text-center py-8">
-                        <CalendarDays className="h-12 w-12 text-gray-400 dark:text-gray-600 mx-auto mb-4" />
+                        <CalendarDays className="h-12 w-12 text-gray-400 dark:text-white/40 mx-auto mb-4" />
                         <p className="text-gray-600 dark:text-white/60">Bu kredi için ödeme planı bulunamadı.</p>
                       </div>
                     ) : (

--- a/app/uygulama/krediler/page.tsx
+++ b/app/uygulama/krediler/page.tsx
@@ -503,7 +503,7 @@ export default function KredilerPage() {
           <div className="p-6 dark:bg-black/20">
             {currentItems.length === 0 && !loadingData && (
               <div className="text-center py-10">
-                <CreditCard className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600" />
+                <CreditCard className="mx-auto h-12 w-12 text-gray-400 dark:text-white/40" />
                 <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">Kredi Bulunamadı</h3>
                 <p className="mt-1 text-sm text-gray-500 dark:text-white/60">
                   {activeTab === "tumKrediler" ? "Hiç kredi eklenmemiş." : "Bu filtreye uygun kredi bulunamadı."}
@@ -528,7 +528,7 @@ export default function KredilerPage() {
                       key={kredi.id}
                       className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-white/10 overflow-hidden dark:bg-black/10"
                     >
-                      <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700">
+                      <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-emerald-900/20 dark:to-emerald-900/10">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-3">
                             <div className="relative">
@@ -536,7 +536,7 @@ export default function KredilerPage() {
                                 bankName={kredi.banks?.name || "Bilinmeyen Banka"}
                                 logoUrl={kredi.banks?.logo_url ?? undefined}
                                 size="md"
-                                className="ring-2 ring-white dark:ring-gray-600 shadow-lg"
+                                className="ring-2 ring-white dark:ring-white/20 shadow-lg"
                               />
                               <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center">
                                 <CheckCircle className="h-2.5 w-2.5 text-white" />
@@ -735,7 +735,7 @@ export default function KredilerPage() {
                                 bankName={kredi.banks?.name || "Bilinmeyen Banka"}
                                 logoUrl={kredi.banks?.logo_url ?? undefined}
                                 size="md"
-                                className="ring-1 ring-emerald-200 dark:ring-gray-700 bg-white dark:bg-black/10"
+                                className="ring-1 ring-emerald-200 dark:ring-emerald-900/30 bg-white dark:bg-black/10"
                               />
                               <div>
                                 <span className="font-medium text-gray-900 dark:text-white block">

--- a/app/uygulama/krediler/pdf-odeme-plani/page.tsx
+++ b/app/uygulama/krediler/pdf-odeme-plani/page.tsx
@@ -260,7 +260,7 @@ export default function PDFOdemePlaniPage() {
       </Card>
 
       <Card className="shadow-lg border-gray-200 dark:border-white/10 rounded-2xl overflow-hidden dark:bg-black/20">
-        <CardHeader className="bg-gradient-to-r from-gray-50 to-purple-50 dark:from-gray-800 dark:to-purple-900/30 border-b dark:border-white/10">
+        <CardHeader className="bg-gradient-to-r from-gray-50 to-purple-50 dark:from-emerald-900/20 dark:to-purple-900/30 border-b dark:border-white/10">
           <CardTitle className="flex items-center gap-2 dark:text-white">
             <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             PDF Dosyası Yükle
@@ -376,7 +376,7 @@ export default function PDFOdemePlaniPage() {
             transition={{ duration: 0.6, delay: 0.5 + index * 0.1 }}
             whileHover={{ y: -5 }}
           >
-            <Card className="text-center p-6 border-0 shadow-lg hover:shadow-xl transition-all duration-300 rounded-2xl dark:bg-black/20 dark:border-gray-800">
+            <Card className="text-center p-6 border-0 shadow-lg hover:shadow-xl transition-all duration-300 rounded-2xl dark:bg-black/20 dark:border-white/10">
               <motion.div
                 className={`w-14 h-14 bg-gradient-to-br ${feature.color} rounded-2xl flex items-center justify-center mx-auto mb-4`}
                 whileHover={{ scale: 1.1, rotate: 5 }}

--- a/app/uygulama/odeme-detay/[id]/page.tsx
+++ b/app/uygulama/odeme-detay/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
             <div className="text-red-600 dark:text-red-400 mb-4">
               <FileText className="h-12 w-12 mx-auto" />
             </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Ödeme Detayı Bulunamadı</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Ödeme Detayı Bulunamadı</h3>
             <p className="text-gray-600 dark:text-white/60 mb-4">
               {error || "Aradığınız ödeme detayı bulunamadı veya erişim izniniz bulunmuyor."}
             </p>
@@ -219,14 +219,14 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
           {/* Payment Information */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-4">
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+              <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                 <CreditCard className="h-5 w-5 text-emerald-600" />
                 Ödeme Bilgileri
               </h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Ödeme Tarihi:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                  <span className="font-medium text-gray-900 dark:text-white">
                     {new Date(payment.payment_date).toLocaleDateString("tr-TR", {
                       weekday: "long",
                       year: "numeric",
@@ -237,7 +237,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Ödeme Saati:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                  <span className="font-medium text-gray-900 dark:text-white">
                     {new Date(payment.created_at).toLocaleTimeString("tr-TR", {
                       hour: "2-digit",
                       minute: "2-digit",
@@ -247,20 +247,20 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Ödeme Kanalı:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                  <span className="font-medium text-gray-900 dark:text-white">
                     {payment.payment_channel || "Belirtilmemiş"}
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Referans No:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="font-medium text-gray-900 dark:text-white font-mono">
                     {payment.transaction_id || "N/A"}
                   </span>
                 </div>
                 {payment.transaction_id && (
                   <div className="flex justify-between">
                     <span className="text-gray-600 dark:text-white/60">İşlem ID:</span>
-                    <span className="font-medium text-gray-900 dark:text-gray-100 font-mono text-sm">
+                    <span className="font-medium text-gray-900 dark:text-white font-mono text-sm">
                       {payment.transaction_id}
                     </span>
                   </div>
@@ -269,31 +269,31 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
             </div>
 
             <div className="space-y-4">
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+              <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                 <Building2 className="h-5 w-5 text-blue-600" />
                 Kredi Bilgileri
               </h3>
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Banka:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100">{payment.credits.banks.name}</span>
+                  <span className="font-medium text-gray-900 dark:text-white">{payment.credits.banks.name}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Kredi Türü:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                  <span className="font-medium text-gray-900 dark:text-white">
                     {payment.credits.credit_types.name}
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-600 dark:text-white/60">Kredi Kodu:</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="font-medium text-gray-900 dark:text-white font-mono">
                     {payment.credits.credit_code}
                   </span>
                 </div>
                 {payment.credits.account_number && (
                   <div className="flex justify-between">
                     <span className="text-gray-600 dark:text-white/60">Hesap No:</span>
-                    <span className="font-medium text-gray-900 dark:text-gray-100 font-mono">
+                    <span className="font-medium text-gray-900 dark:text-white font-mono">
                       {payment.credits.account_number}
                     </span>
                   </div>
@@ -306,13 +306,13 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
 
           {/* Payment Amount Breakdown */}
           <div className="space-y-4">
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
               <Hash className="h-5 w-5 text-purple-600" />
               Ödeme Detayı
             </h3>
             <div className="bg-gray-50 dark:bg-black/10 rounded-lg p-4">
               <div className="flex justify-between items-center">
-                <span className="text-lg font-medium text-gray-900 dark:text-gray-100">Ödenen Tutar:</span>
+                <span className="text-lg font-medium text-gray-900 dark:text-white">Ödenen Tutar:</span>
                 <span className="text-2xl font-bold text-emerald-600">{formatCurrency(payment.amount)}</span>
               </div>
             </div>
@@ -323,7 +323,7 @@ export default function PaymentDetailPage({ params }: { params: { id: string } }
             <>
               <Separator />
               <div className="space-y-4">
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                   <FileText className="h-5 w-5 text-orange-600" />
                   Notlar
                 </h3>

--- a/app/uygulama/odeme-plani/page.tsx
+++ b/app/uygulama/odeme-plani/page.tsx
@@ -301,7 +301,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
                 isToday
                   ? "bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 shadow-md ring-2 ring-blue-200 dark:ring-blue-800"
                   : dayPayments.length > 0
-                    ? "bg-white dark:bg-black/20 border-gray-300 dark:border-white/10 hover:border-gray-400 dark:hover:border-gray-600"
+                    ? "bg-white dark:bg-black/20 border-gray-300 dark:border-white/10 hover:border-gray-400 dark:hover:border-white/20"
                     : "bg-gray-50/50 dark:bg-black/10/50 border-gray-200 dark:border-white/10"
               }`}
             >
@@ -316,7 +316,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
               >
                 {day}
                 {isToday && (
-                  <span className="ml-1 text-xs bg-gray-600 dark:bg-gray-700 text-white px-1 rounded">Bugün</span>
+                  <span className="ml-1 text-xs bg-gray-600 dark:bg-emerald-900/30 text-white px-1 rounded">Bugün</span>
                 )}
               </div>
 
@@ -367,7 +367,7 @@ function CalendarView({ payments }: { payments: PaymentWithCredit[] }) {
       {uniqueBanks.length > 0 && (
         <div className="mt-6">
           <h4 className="text-sm font-semibold text-gray-700 dark:text-white/70 mb-3 flex items-center gap-2">
-            <div className="w-2 h-2 bg-gray-400 dark:bg-gray-600 rounded-full"></div>
+            <div className="w-2 h-2 bg-gray-400 dark:bg-white/40 rounded-full"></div>
             Banka Renk Kodları
           </h4>
           <div className="flex flex-wrap gap-3">
@@ -835,7 +835,7 @@ function PaymentsList({
 
       {currentPayments.length === 0 && (
         <div className="text-center py-12 text-gray-500 dark:text-white/60">
-          <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-gray-600" />
+          <Calendar className="h-16 w-16 mx-auto mb-4 text-gray-400 dark:text-white/40" />
           <h3 className="font-medium text-gray-900 dark:text-white mb-2">Ödeme Bulunamadı</h3>
           <p className="text-sm">Seçilen filtrelere uygun ödeme bulunmuyor</p>
         </div>
@@ -1086,7 +1086,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
                         </div>
                         <span className="text-sm font-semibold dark:text-white">{formatCurrency(data.total)}</span>
                       </div>
-                      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                      <div className="w-full bg-gray-200 dark:bg-emerald-900/20 rounded-full h-2">
                         <div
                           className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300"
                           style={{
@@ -1122,7 +1122,7 @@ function PaymentAnalysis({ payments, credits }: { payments: PaymentWithCredit[];
                     </span>
                     <span className="text-sm font-semibold dark:text-white">{formatCurrency(month.total)}</span>
                   </div>
-                  <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                  <div className="w-full bg-gray-200 dark:bg-emerald-900/20 rounded-full h-2">
                     <div className="flex h-2 rounded-full overflow-hidden">
                       <div
                         className="bg-emerald-500 transition-all duration-300"
@@ -1519,7 +1519,7 @@ function ReminderSettings({ payments }: { payments: PaymentWithCredit[] }) {
             </div>
           ) : (
             <div className="text-center py-8 text-gray-500 dark:text-white/60">
-              <Bell className="h-12 w-12 mx-auto mb-3 text-gray-400 dark:text-gray-600" />
+              <Bell className="h-12 w-12 mx-auto mb-3 text-gray-400 dark:text-white/40" />
               <p className="font-medium dark:text-white/70">Yaklaşan ödeme yok</p>
               <p className="text-sm">Önümüzdeki 7 gün içinde vadesi gelen ödeme bulunmuyor</p>
             </div>
@@ -1713,28 +1713,28 @@ export default function OdemePlaniPage() {
             <TabsList className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 bg-transparent h-auto p-2 gap-2">
               <TabsTrigger
                 value="takvim"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-emerald-900/20 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
               >
                 <Calendar className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Takvim</span>
               </TabsTrigger>
               <TabsTrigger
                 value="liste"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-emerald-900/20 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
               >
                 <CreditCard className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Liste</span>
               </TabsTrigger>
               <TabsTrigger
                 value="analiz"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-emerald-900/20 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
               >
                 <TrendingUp className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Analiz</span>
               </TabsTrigger>
               <TabsTrigger
                 value="hatirlatici"
-                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-gray-900 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
+                className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 data-[state=active]:bg-white dark:data-[state=active]:bg-emerald-900/20 data-[state=active]:shadow-sm rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
               >
                 <Bell className="h-4 w-4" />
                 <span className="hidden sm:inline font-medium">Hatırlatıcı</span>

--- a/app/uygulama/premium/page.tsx
+++ b/app/uygulama/premium/page.tsx
@@ -296,7 +296,7 @@ export default function PremiumPage() {
               </div>
               {isPremium && subscription?.plan_id === (isYearly ? "premium-yearly" : "premium-monthly") ? (
                 <Button
-                  className="w-full bg-gray-400 dark:bg-gray-600 cursor-not-allowed shadow-lg mt-auto opacity-60"
+                  className="w-full bg-gray-400 dark:bg-emerald-900/40 cursor-not-allowed shadow-lg mt-auto opacity-60"
                   disabled
                   size="lg"
                 >
@@ -431,7 +431,7 @@ export default function PremiumPage() {
           <div className="py-4">
             <div className="space-y-3">
               <div className="p-4 bg-gray-50 dark:bg-black/10 rounded-lg">
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">Mevcut Plan:</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-white mb-2">Mevcut Plan:</p>
                 <div className="flex items-center justify-between">
                   <span className="text-base text-gray-700 dark:text-white/70">
                     {subscription?.plan_id === "premium-yearly" ? "Yıllık Premium" : "Aylık Premium"}

--- a/app/uygulama/raporlar/page.tsx
+++ b/app/uygulama/raporlar/page.tsx
@@ -614,7 +614,7 @@ export default function RaporlarPage() {
       </div>
 
       {/* Premium Filters */}
-      <Card className="shadow-xl border-0 bg-gradient-to-br from-slate-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
+      <Card className="shadow-xl border-0 bg-gradient-to-br from-slate-50 to-gray-100 dark:from-emerald-950 dark:to-emerald-900/30">
         <CardHeader className="pb-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -734,12 +734,12 @@ export default function RaporlarPage() {
             </Popover>
 
             {/* Quick Stats */}
-            <div className="flex items-center justify-center gap-4 text-sm text-gray-600 dark:text-white/70 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-lg px-4 py-2">
+            <div className="flex items-center justify-center gap-4 text-sm text-gray-600 dark:text-white/70 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-emerald-900/20 dark:to-emerald-900/10 rounded-lg px-4 py-2">
               <div className="flex items-center gap-1">
                 <CreditCard className="h-4 w-4" />
                 <span>{filteredCredits.length} kredi</span>
               </div>
-              <div className="w-px h-4 bg-gray-300 dark:bg-gray-600"></div>
+              <div className="w-px h-4 bg-gray-300 dark:bg-white/30"></div>
               <div className="flex items-center gap-1">
                 <Activity className="h-4 w-4" />
                 <span>{filteredPayments.length} ödeme</span>
@@ -898,7 +898,7 @@ export default function RaporlarPage() {
           <div className="p-6">
             <TabsContent value="overview" className="space-y-6 mt-0">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-blue-50 dark:from-gray-900 dark:to-blue-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-blue-50 dark:from-emerald-950 dark:to-blue-950">
                   <CardHeader className="pb-4">
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-blue-500 to-indigo-600 rounded-lg">
@@ -941,7 +941,7 @@ export default function RaporlarPage() {
                   </CardContent>
                 </Card>
 
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-emerald-50 dark:from-gray-900 dark:to-emerald-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-emerald-50 dark:from-emerald-950 dark:to-emerald-900/30">
                   <CardHeader className="pb-4">
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-600 rounded-lg">
@@ -1073,7 +1073,7 @@ export default function RaporlarPage() {
             </TabsContent>
 
             <TabsContent value="trends" className="space-y-6 mt-0">
-              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-purple-50 dark:from-gray-900 dark:to-purple-950">
+              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-purple-50 dark:from-emerald-950 dark:to-purple-950">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 text-xl dark:text-white">
                     <div className="p-2 bg-gradient-to-r from-purple-500 to-pink-600 rounded-lg">
@@ -1139,7 +1139,7 @@ export default function RaporlarPage() {
 
             <TabsContent value="distribution" className="space-y-6 mt-0">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-blue-50 dark:from-gray-900 dark:to-blue-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-blue-50 dark:from-emerald-950 dark:to-blue-950">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-blue-500 to-indigo-600 rounded-lg">
@@ -1172,7 +1172,7 @@ export default function RaporlarPage() {
                   </CardContent>
                 </Card>
 
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-emerald-50 dark:from-gray-900 dark:to-emerald-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-emerald-50 dark:from-emerald-950 dark:to-emerald-900/30">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-600 rounded-lg">
@@ -1207,7 +1207,7 @@ export default function RaporlarPage() {
             </TabsContent>
 
             <TabsContent value="performance" className="space-y-6 mt-0">
-              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-orange-50 dark:from-gray-900 dark:to-orange-950">
+              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-orange-50 dark:from-emerald-950 dark:to-orange-950">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 text-xl dark:text-white">
                     <div className="p-2 bg-gradient-to-r from-orange-500 to-red-600 rounded-lg">
@@ -1275,7 +1275,7 @@ export default function RaporlarPage() {
             </TabsContent>
 
             <TabsContent value="analysis" className="space-y-6 mt-0">
-              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-purple-50 dark:from-gray-900 dark:to-purple-950">
+              <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-purple-50 dark:from-emerald-950 dark:to-purple-950">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 text-xl dark:text-white">
                     <div className="p-2 bg-gradient-to-r from-purple-500 to-pink-600 rounded-lg">
@@ -1314,7 +1314,7 @@ export default function RaporlarPage() {
 
             <TabsContent value="comparison" className="space-y-6 mt-0">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-indigo-50 dark:from-gray-900 dark:to-indigo-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-indigo-50 dark:from-emerald-950 dark:to-indigo-950">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-lg">
@@ -1328,7 +1328,7 @@ export default function RaporlarPage() {
                       {chartData.bankDistribution.slice(0, 5).map((bank, index) => (
                         <div
                           key={bank.name}
-                          className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-gray-800 dark:to-gray-700 rounded-xl border dark:border-white/10 shadow-sm"
+                          className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-slate-100 dark:from-emerald-900/20 dark:to-emerald-900/10 rounded-xl border dark:border-white/10 shadow-sm"
                         >
                           <div className="flex items-center gap-4">
                             <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-sm font-bold text-white">
@@ -1354,7 +1354,7 @@ export default function RaporlarPage() {
                   </CardContent>
                 </Card>
 
-                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-green-50 dark:from-gray-900 dark:to-green-950">
+                <Card className="shadow-xl border-0 bg-gradient-to-br from-white to-green-50 dark:from-emerald-950 dark:to-green-950">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 text-lg dark:text-white">
                       <div className="p-2 bg-gradient-to-r from-green-500 to-emerald-600 rounded-lg">

--- a/app/uygulama/risk-analizi/[id]/page.tsx
+++ b/app/uygulama/risk-analizi/[id]/page.tsx
@@ -157,7 +157,7 @@ const SectionCard: React.FC<{
                 {icon}
               </span>
               <div>
-                <CardTitle className="text-xl font-semibold text-gray-800 dark:text-gray-100">{title}</CardTitle>
+                <CardTitle className="text-xl font-semibold text-gray-800 dark:text-white">{title}</CardTitle>
                 {description && (
                   <CardDescription className="text-sm text-gray-500 dark:text-white/60">{description}</CardDescription>
                 )}

--- a/app/uygulama/risk-analizi/page.tsx
+++ b/app/uygulama/risk-analizi/page.tsx
@@ -542,28 +542,28 @@ export default function RiskAnaliziPage() {
                 <TabsList className="grid grid-cols-2 sm:grid-cols-4 bg-transparent h-auto p-2 gap-2">
                   <TabsTrigger
                     value="tumAnalizler"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/70"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
                   >
                     <ListChecks className="h-4 w-4" />
                     Tümü ({totalAnalysesCount})
                   </TabsTrigger>
                   <TabsTrigger
                     value="dusukRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/70"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
                   >
                     <CheckCircle className="h-4 w-4" />
                     Düşük ({riskDistribution.low})
                   </TabsTrigger>
                   <TabsTrigger
                     value="ortaRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/70"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
                   >
                     <Clock className="h-4 w-4" />
                     Orta ({riskDistribution.medium})
                   </TabsTrigger>
                   <TabsTrigger
                     value="yuksekRisk"
-                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/70"
+                    className="flex items-center gap-2 py-3 px-4 data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400 rounded-xl transition-all duration-200 hover:bg-gray-100 dark:hover:bg-white/10 dark:text-white/60"
                   >
                     <AlertTriangle className="h-4 w-4" />
                     Yüksek ({riskDistribution.high})

--- a/app/uygulama/sifrelerim/page.tsx
+++ b/app/uygulama/sifrelerim/page.tsx
@@ -668,7 +668,7 @@ export default function BankaciSifrelerimPage() {
                         key={credential.id}
                         className="shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 rounded-xl border-gray-200 dark:border-white/10 overflow-hidden"
                       >
-                        <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700">
+                        <CardHeader className="pb-3 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-emerald-900/20 dark:to-emerald-900/10">
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-3">
                               <div className="relative">
@@ -1027,7 +1027,7 @@ export default function BankaciSifrelerimPage() {
               placeholder="Yeni şifrenizi girin..."
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
-              className="dark:bg-gray-700 dark:border-white/10 dark:text-white"
+              className="dark:bg-black/20 dark:border-white/10 dark:text-white"
               disabled={isUpdatingPassword}
             />
           </div>
@@ -1039,7 +1039,7 @@ export default function BankaciSifrelerimPage() {
                 setNewPassword("")
               }}
               disabled={isUpdatingPassword}
-              className="dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+              className="dark:bg-black/20 dark:text-white dark:hover:bg-white/10"
             >
               İptal
             </AlertDialogCancel>
@@ -1117,7 +1117,7 @@ function PasswordDisplay({
 
   return (
     <div className="flex items-center gap-2">
-      <code className="bg-gray-100 dark:bg-black/10 px-2 py-1 rounded text-sm font-mono max-w-[120px] truncate text-gray-900 dark:text-gray-100">
+      <code className="bg-gray-100 dark:bg-black/10 px-2 py-1 rounded text-sm font-mono max-w-[120px] truncate text-gray-900 dark:text-white">
         {displayPassword()}
       </code>
       <div className="flex gap-1">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -172,9 +172,9 @@ export default function AppSidebar() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-950 border-r border-gray-200/50 dark:border-gray-800/50">
+    <div className="flex flex-col h-full bg-gradient-to-b from-gray-50 to-white dark:from-emerald-950/30 dark:to-emerald-950/50 border-r border-gray-200/50 dark:border-white/10">
       {/* Header with Logo */}
-      <div className="h-16 bg-gray-50 dark:bg-gray-900 border-b border-gray-200/50 dark:border-gray-800/50">
+      <div className="h-16 bg-gray-50 dark:bg-black/20 border-b border-gray-200/50 dark:border-white/10">
         <div className={`h-full flex items-center justify-center transition-all duration-300 ${isCollapsed ? "px-2" : "px-6"}`}>
           <Link href="/uygulama/ana-sayfa" className="flex items-center gap-3 group">
             {/* Logo Icon */}
@@ -216,7 +216,7 @@ export default function AppSidebar() {
                   ${isCollapsed ? "justify-center h-12 w-12" : "gap-3.5 px-4 h-12"}
                   ${isActive
                     ? `bg-gradient-to-r ${item.gradient} text-white shadow-lg shadow-${item.gradient.split(' ')[1]}/30`
-                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/50"
+                    : "text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20"
                   }
                 `}
               >
@@ -228,7 +228,7 @@ export default function AppSidebar() {
                     <div className="absolute inset-0 bg-white/20 rounded-lg blur-md"></div>
                   )}
                   <Icon className={`relative h-5 w-5 flex-shrink-0 transition-all duration-300 ${
-                    isActive ? "text-white" : "text-gray-600 dark:text-gray-400 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400"
+                    isActive ? "text-white" : "text-gray-600 dark:text-white/40 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400"
                   }`} />
                 </div>
 
@@ -275,7 +275,7 @@ export default function AppSidebar() {
       </div>
 
       {/* Footer Section */}
-      <div className={`border-t border-gray-200/50 dark:border-gray-800/50 space-y-1.5 py-3 ${isCollapsed ? "px-2" : "px-3"}`}>
+      <div className={`border-t border-gray-200/50 dark:border-white/10 space-y-1.5 py-3 ${isCollapsed ? "px-2" : "px-3"}`}>
         {/* Settings Items */}
         {settingsItems.map((item) => {
           const isActive = pathname === item.href
@@ -290,7 +290,7 @@ export default function AppSidebar() {
                   ${isCollapsed ? "justify-center h-10 w-10" : "gap-3 px-4 h-10"}
                   ${isActive
                     ? "bg-gradient-to-r from-emerald-500 to-teal-600 text-white shadow-lg shadow-emerald-500/30"
-                    : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-gray-200"
+                    : "text-gray-600 dark:text-white/60 hover:bg-gray-100 dark:hover:bg-emerald-900/20 hover:text-gray-900 dark:hover:text-gray-200"
                   }
                 `}
               >
@@ -301,7 +301,7 @@ export default function AppSidebar() {
                     <div className="absolute inset-0 bg-white/20 rounded-lg blur-md"></div>
                   )}
                   <Icon className={`relative h-5 w-5 flex-shrink-0 transition-all duration-300 ${
-                    isActive ? "text-white" : "text-gray-600 dark:text-gray-400 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400"
+                    isActive ? "text-white" : "text-gray-600 dark:text-white/40 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400"
                   }`} />
                   {item.label === "Bildirimler" && unreadCount > 0 && (
                     <div className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 bg-red-500 rounded-full border-2 border-white dark:border-gray-900 flex items-center justify-center z-10">
@@ -345,14 +345,14 @@ export default function AppSidebar() {
             className={`
               relative flex items-center rounded-xl transition-all duration-300 group/link
               ${isCollapsed ? "justify-center h-10 w-10" : "gap-3 px-4 h-10"}
-              text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-gray-200
+              text-gray-600 dark:text-white/60 hover:bg-gray-100 dark:hover:bg-emerald-900/20 hover:text-gray-900 dark:hover:text-gray-200
             `}
           >
             <div className="relative flex items-center justify-center transition-all duration-300 group-hover/link:scale-105">
               {isCollapsed ? (
-                <PanelLeftOpen className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-gray-400 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400 transition-all duration-300" />
+                <PanelLeftOpen className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-white/40 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400 transition-all duration-300" />
               ) : (
-                <PanelLeftClose className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-gray-400 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400 transition-all duration-300" />
+                <PanelLeftClose className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-white/40 group-hover/link:text-emerald-600 dark:group-hover/link:text-emerald-400 transition-all duration-300" />
               )}
             </div>
             {!isCollapsed && (
@@ -416,7 +416,7 @@ export default function AppSidebar() {
                           ? `${profile.first_name} ${profile.last_name}`
                           : user?.email || "Kullanıcı"}
                     </span>
-                    <span className="truncate text-xs text-gray-500 dark:text-gray-400">
+                    <span className="truncate text-xs text-gray-500 dark:text-white/60">
                       {isPremium ? "Premium Üye" : "Ücretsiz"}
                     </span>
                   </div>
@@ -431,7 +431,7 @@ export default function AppSidebar() {
             <DropdownMenuContent
               side={isCollapsed ? "right" : "top"}
               align="start"
-              className="w-64 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 shadow-xl"
+              className="w-64 bg-white dark:bg-black/20 dark:backdrop-blur-xl border-gray-200 dark:border-white/10 shadow-xl"
             >
               <DropdownMenuLabel className="text-gray-900 dark:text-white">
                 <div className="flex items-center gap-2">
@@ -439,17 +439,17 @@ export default function AppSidebar() {
                   {isPremium && <Crown className="h-4 w-4 text-amber-500" />}
                 </div>
               </DropdownMenuLabel>
-              <DropdownMenuSeparator className="bg-gray-200 dark:bg-gray-800" />
+              <DropdownMenuSeparator className="bg-gray-200 dark:bg-emerald-900/20" />
               <DropdownMenuItem
                 onClick={() => router.push("/uygulama/ayarlar")}
-                className="text-gray-700 dark:text-gray-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
+                className="text-gray-700 dark:text-white/70 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
               >
                 <UserIcon className="mr-3 h-4 w-4" />
                 Profil Ayarları
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => router.push("/uygulama/faturalandirma")}
-                className="text-gray-700 dark:text-gray-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
+                className="text-gray-700 dark:text-white/70 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
               >
                 <Briefcase className="mr-3 h-4 w-4" />
                 Faturalandırma
@@ -465,12 +465,12 @@ export default function AppSidebar() {
               )}
               <DropdownMenuItem
                 onClick={() => window.open("https://www.kreditakip.com.tr/sss", "_blank")}
-                className="text-gray-700 dark:text-gray-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
+                className="text-gray-700 dark:text-white/70 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 focus:bg-emerald-50 dark:focus:bg-emerald-950/30 cursor-pointer"
               >
                 <HelpCircle className="mr-3 h-4 w-4" />
                 Yardım & Destek
               </DropdownMenuItem>
-              <DropdownMenuSeparator className="bg-gray-200 dark:bg-gray-800" />
+              <DropdownMenuSeparator className="bg-gray-200 dark:bg-emerald-900/20" />
               <DropdownMenuItem
                 onClick={handleSignOut}
                 className="text-red-600 dark:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 focus:bg-red-50 dark:focus:bg-red-950/30 font-medium cursor-pointer"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -554,25 +554,25 @@ export default function Header({ pageTitle }: HeaderProps) {
   }
 
   return (
-    <header className="sticky top-0 z-50 flex h-16 items-center gap-4 border-b bg-white/80 dark:bg-gray-900/80 backdrop-blur-md supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-gray-900/60 px-4 sm:px-6 md:px-8 shadow-sm border-emerald-100 dark:border-gray-700">
+    <header className="sticky top-0 z-50 flex h-16 items-center gap-4 border-b bg-white/80 dark:bg-black/20 backdrop-blur-md supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-black/20 px-4 sm:px-6 md:px-8 shadow-sm border-emerald-100 dark:border-white/10">
       {isMobile ? (
         <Sheet>
           <SheetTrigger asChild>
             <Button
               variant="outline"
               size="icon"
-              className="shrink-0 md:hidden bg-transparent border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+              className="shrink-0 md:hidden bg-transparent border-gray-200 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-emerald-900/20"
             >
-              <Menu className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+              <Menu className="h-5 w-5 text-gray-700 dark:text-white/70" />
               <span className="sr-only">Toggle navigation menu</span>
             </Button>
           </SheetTrigger>
           <SheetContent
             side="left"
-            className="flex flex-col p-0 w-80 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700"
+            className="flex flex-col p-0 w-80 bg-white dark:bg-black/20 border-gray-200 dark:border-white/10"
           >
             {/* Mobile Header */}
-            <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+            <div className="p-4 border-b border-gray-200 dark:border-white/10 bg-white dark:bg-black/20">
               <Link
                 href="/uygulama/ana-sayfa"
                 className="flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
@@ -583,7 +583,7 @@ export default function Header({ pageTitle }: HeaderProps) {
             </div>
 
             {/* Mobile Navigation */}
-            <div className="flex-1 p-2 space-y-1 bg-white dark:bg-gray-900">
+            <div className="flex-1 p-2 space-y-1 bg-white dark:bg-black/20">
               {navItems.map((item) => {
                 const isActive = pathname === item.href
                 return (
@@ -593,7 +593,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                     className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 ${
                       isActive
                         ? "bg-gradient-to-r from-emerald-600 to-teal-700 dark:from-emerald-500 dark:to-teal-600 text-white shadow-sm"
-                        : "hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-gray-300 hover:text-emerald-700 dark:hover:text-emerald-400"
+                        : "hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-white/70 hover:text-emerald-700 dark:hover:text-emerald-400"
                     }`}
                   >
                     <item.icon className="h-5 w-5 flex-shrink-0" />
@@ -604,7 +604,7 @@ export default function Header({ pageTitle }: HeaderProps) {
             </div>
 
             {/* Mobile Footer */}
-            <div className="p-2 border-t border-gray-200 dark:border-gray-700 space-y-1 bg-white dark:bg-gray-900">
+            <div className="p-2 border-t border-gray-200 dark:border-white/10 space-y-1 bg-white dark:bg-black/20">
               {settingsItems.map((item) => {
                 const isActive = pathname === item.href
                 return (
@@ -614,7 +614,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                     className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 ${
                       isActive
                         ? "bg-gradient-to-r from-emerald-600 to-teal-700 dark:from-emerald-500 dark:to-teal-600 text-white shadow-sm"
-                        : "hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-gray-300 hover:text-emerald-700 dark:hover:text-emerald-400"
+                        : "hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-white/70 hover:text-emerald-700 dark:hover:text-emerald-400"
                     }`}
                   >
                     <item.icon className="h-5 w-5 flex-shrink-0" />
@@ -626,14 +626,14 @@ export default function Header({ pageTitle }: HeaderProps) {
               {/* Yardım & Destek Link */}
               <button
                 onClick={() => window.open("https://www.kreditakip.com.tr/sss", "_blank")}
-                className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-gray-300 hover:text-emerald-700 dark:hover:text-emerald-400"
+                className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-gray-700 dark:text-white/70 hover:text-emerald-700 dark:hover:text-emerald-400"
               >
                 <HelpCircle className="h-5 w-5 flex-shrink-0" />
                 <span>Yardım & Destek</span>
               </button>
 
               {/* Mobile User Section */}
-              <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <div className="pt-2 border-t border-gray-200 dark:border-white/10">
                 <div className="flex items-center gap-3 px-3 py-2">
                   <Avatar className="h-8 w-8">
                     <AvatarImage
@@ -673,17 +673,17 @@ export default function Header({ pageTitle }: HeaderProps) {
         <div className="flex flex-col gap-1 min-w-0">
           {/* Breadcrumb */}
           {pageInfo.parent && (
-            <div className="hidden lg:flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <div className="hidden lg:flex items-center gap-2 text-sm text-gray-500 dark:text-white/60">
               <span className="font-medium">{pageInfo.parent}</span>
               <svg
-                className="w-3 h-3 text-gray-400 dark:text-gray-500"
+                className="w-3 h-3 text-gray-400 dark:text-white/60"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              <span className="font-medium text-gray-700 dark:text-gray-300">{pageInfo.title}</span>
+              <span className="font-medium text-gray-700 dark:text-white/70">{pageInfo.title}</span>
             </div>
           )}
 
@@ -695,7 +695,7 @@ export default function Header({ pageTitle }: HeaderProps) {
               </h1>
             )}
             {pageInfo.description && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 truncate max-w-[400px] hidden md:block leading-tight">
+              <p className="text-sm text-gray-500 dark:text-white/60 truncate max-w-[400px] hidden md:block leading-tight">
                 {pageInfo.description}
               </p>
             )}
@@ -704,25 +704,25 @@ export default function Header({ pageTitle }: HeaderProps) {
 
         <form className="ml-auto flex-1 sm:flex-initial">
           <div className="relative" ref={searchRef}>
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400 dark:text-gray-500 pointer-events-none" />
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400 dark:text-white/60 pointer-events-none" />
             <Input
               type="search"
               placeholder="Ara..."
               value={searchQuery}
               onChange={handleSearchChange}
               onKeyDown={handleSearchKeyDown}
-              className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 focus-visible:border-emerald-500 dark:focus-visible:border-emerald-400 focus-visible:shadow-[0_0_0_0.5px_rgb(16,185,129)] dark:focus-visible:shadow-[0_0_0_0.5px_rgb(52,211,153)] transition-all duration-200 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-gray-400"
+              className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] rounded-lg bg-white dark:bg-black/10 border border-gray-200 dark:border-white/10 focus-visible:border-emerald-500 dark:focus-visible:border-emerald-400 focus-visible:shadow-[0_0_0_0.5px_rgb(16,185,129)] dark:focus-visible:shadow-[0_0_0_0.5px_rgb(52,211,153)] transition-all duration-200 text-gray-900 dark:text-white placeholder:text-gray-500 dark:placeholder:text-white/50"
               aria-label="Search"
               autoComplete="off"
               spellCheck="false"
             />
 
             {searchOpen && searchQuery.length >= 2 && (
-              <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 z-50 max-h-96 overflow-y-auto">
+              <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-black/20 dark:backdrop-blur-xl rounded-lg shadow-2xl border border-gray-200 dark:border-white/10 z-50 max-h-96 overflow-y-auto">
                 {searchLoading ? (
                   <div className="p-4 text-center">
                     <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-emerald-600 mx-auto"></div>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">Aranıyor...</p>
+                    <p className="text-sm text-gray-500 dark:text-white/60 mt-2">Aranıyor...</p>
                   </div>
                 ) : searchResults.length > 0 ? (
                   <div className="py-2">
@@ -730,7 +730,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                       <button
                         key={`${result.type}-${result.id}`}
                         onClick={() => handleSearchResultClick(result)}
-                        className="w-full px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150 flex items-center gap-3"
+                        className="w-full px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-emerald-900/20 transition-colors duration-150 flex items-center gap-3"
                       >
                         <div className="flex-shrink-0">
                           {result.type === "credit" && result.icon ? (
@@ -738,7 +738,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                               bankName={result.title}
                               logoUrl={result.icon}
                               size="sm"
-                              className="ring-1 ring-gray-200 dark:ring-gray-600"
+                              className="ring-1 ring-gray-200 dark:ring-emerald-900/30"
                             />
                           ) : (
                             <div className="w-8 h-8 bg-emerald-100 dark:bg-emerald-900 rounded-lg flex items-center justify-center">
@@ -774,20 +774,20 @@ export default function Header({ pageTitle }: HeaderProps) {
                               </Badge>
                             )}
                           </div>
-                          <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{result.subtitle}</p>
+                          <p className="text-sm text-gray-500 dark:text-white/60 truncate">{result.subtitle}</p>
                           {result.description && (
-                            <p className="text-xs text-gray-400 dark:text-gray-500 truncate">{result.description}</p>
+                            <p className="text-xs text-gray-400 dark:text-white/60 truncate">{result.description}</p>
                           )}
                         </div>
-                        <ArrowRight className="h-4 w-4 text-gray-400 dark:text-gray-500 flex-shrink-0" />
+                        <ArrowRight className="h-4 w-4 text-gray-400 dark:text-white/60 flex-shrink-0" />
                       </button>
                     ))}
                   </div>
                 ) : (
                   <div className="p-4 text-center">
-                    <Search className="h-8 w-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" />
-                    <p className="text-sm text-gray-500 dark:text-gray-400">"{searchQuery}" için sonuç bulunamadı</p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                    <Search className="h-8 w-8 text-gray-400 dark:text-white/60 mx-auto mb-2" />
+                    <p className="text-sm text-gray-500 dark:text-white/60">"{searchQuery}" için sonuç bulunamadı</p>
+                    <p className="text-xs text-gray-400 dark:text-white/60 mt-1">
                       Kredi, banka adı veya sayfa adı arayın
                     </p>
                   </div>
@@ -801,14 +801,14 @@ export default function Header({ pageTitle }: HeaderProps) {
         <Button
           variant="ghost"
           size="icon"
-          className="rounded-full h-10 w-10 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          className="rounded-full h-10 w-10 hover:bg-gray-100 dark:hover:bg-emerald-900/20 transition-colors"
           onClick={toggleTheme}
           aria-label="Tema değiştir"
         >
           {isDarkMode ? (
-            <Sun className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <Sun className="h-5 w-5 text-gray-600 dark:text-white/60" />
           ) : (
-            <Moon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <Moon className="h-5 w-5 text-gray-600 dark:text-white/60" />
           )}
         </Button>
 
@@ -821,7 +821,7 @@ export default function Header({ pageTitle }: HeaderProps) {
             aria-label="Notifications"
             onClick={toggleNotifications}
           >
-            <Bell className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <Bell className="h-5 w-5 text-gray-600 dark:text-white/60" />
             {unreadCount > 0 && (
               <span className="absolute -top-1 -right-1 h-5 w-5 rounded-full bg-gradient-to-r from-red-500 to-red-600 text-white text-xs flex items-center justify-center font-bold shadow-lg animate-pulse">
                 {unreadCount > 9 ? "9+" : unreadCount}
@@ -830,7 +830,7 @@ export default function Header({ pageTitle }: HeaderProps) {
           </Button>
 
           {notificationOpen && (
-            <div className="absolute right-0 top-full mt-3 w-80 bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-100 dark:border-gray-700 z-50 overflow-hidden backdrop-blur-sm">
+            <div className="absolute right-0 top-full mt-3 w-80 bg-white dark:bg-black/20 dark:backdrop-blur-xl rounded-2xl shadow-2xl border border-gray-100 dark:border-white/10 z-50 overflow-hidden backdrop-blur-sm">
               {/* Header */}
               <div className="bg-gradient-to-r from-emerald-600 to-blue-600 dark:from-emerald-500 dark:to-blue-500 p-4 text-white">
                 <div className="flex items-center justify-between">
@@ -869,14 +869,14 @@ export default function Header({ pageTitle }: HeaderProps) {
               </div>
 
               {/* Notifications List */}
-              <div className="max-h-80 overflow-y-auto bg-white dark:bg-gray-800">
+              <div className="max-h-80 overflow-y-auto bg-white dark:bg-black/20">
                 {notifications.length === 0 ? (
                   <div className="p-6 text-center">
-                    <div className="w-12 h-12 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mx-auto mb-3">
-                      <Bell className="h-6 w-6 text-gray-400 dark:text-gray-500" />
+                    <div className="w-12 h-12 bg-gray-100 dark:bg-black/10 rounded-full flex items-center justify-center mx-auto mb-3">
+                      <Bell className="h-6 w-6 text-gray-400 dark:text-white/60" />
                     </div>
-                    <h4 className="font-medium text-gray-700 dark:text-gray-300 mb-1">Henüz bildirim yok</h4>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">Yeni bildirimler burada görünecek</p>
+                    <h4 className="font-medium text-gray-700 dark:text-white/70 mb-1">Henüz bildirim yok</h4>
+                    <p className="text-xs text-gray-500 dark:text-white/60">Yeni bildirimler burada görünecek</p>
                   </div>
                 ) : (
                   <div className="p-2 space-y-1">
@@ -891,7 +891,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                             relative p-3 rounded-lg cursor-pointer transition-all duration-200 group
                             ${
                               notification.is_read
-                                ? "bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+                                ? "bg-gray-50 dark:bg-black/10 hover:bg-gray-100 dark:hover:bg-emerald-900/20"
                                 : "bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-800"
                             }
                           `}
@@ -899,7 +899,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                         >
                           <div className="flex items-start gap-3">
                             <div
-                              className={`p-1.5 rounded-lg bg-white dark:bg-gray-800 shadow-sm ${config.color} flex-shrink-0`}
+                              className={`p-1.5 rounded-lg bg-white dark:bg-black/10 shadow-sm ${config.color} flex-shrink-0`}
                             >
                               <Icon className="h-3 w-3" />
                             </div>
@@ -909,7 +909,7 @@ export default function Header({ pageTitle }: HeaderProps) {
                                 <h4
                                   className={`font-medium text-sm leading-tight ${
                                     notification.is_read
-                                      ? "text-gray-600 dark:text-gray-400"
+                                      ? "text-gray-600 dark:text-white/60"
                                       : "text-gray-900 dark:text-white"
                                   }`}
                                 >
@@ -923,15 +923,15 @@ export default function Header({ pageTitle }: HeaderProps) {
                               <p
                                 className={`text-xs leading-relaxed mb-2 line-clamp-2 ${
                                   notification.is_read
-                                    ? "text-gray-500 dark:text-gray-400"
-                                    : "text-gray-700 dark:text-gray-300"
+                                    ? "text-gray-500 dark:text-white/60"
+                                    : "text-gray-700 dark:text-white/70"
                                 }`}
                               >
                                 {notification.message}
                               </p>
 
                               <div className="flex justify-end">
-                                <span className="text-xs text-gray-400 dark:text-gray-500">
+                                <span className="text-xs text-gray-400 dark:text-white/60">
                                   {formatDistanceToNow(new Date(notification.created_at), {
                                     addSuffix: true,
                                     locale: tr,
@@ -949,7 +949,7 @@ export default function Header({ pageTitle }: HeaderProps) {
 
               {/* Footer */}
               {notifications.length > 0 && (
-                <div className="p-3 bg-gray-50 dark:bg-gray-700 border-t border-gray-200 dark:border-gray-600">
+                <div className="p-3 bg-gray-50 dark:bg-emerald-900/20 border-t border-gray-200 dark:border-white/10">
                   <Link href="/uygulama/bildirimler" onClick={() => setNotificationOpen(false)}>
                     <Button className="w-full bg-gradient-to-r from-emerald-600 to-blue-600 dark:from-emerald-500 dark:to-blue-500 hover:from-emerald-700 hover:to-blue-700 dark:hover:from-emerald-600 dark:hover:to-blue-600 text-white rounded-lg gap-2 transition-all duration-300 text-sm py-2">
                       Tüm Bildirimleri Görüntüle
@@ -967,7 +967,7 @@ export default function Header({ pageTitle }: HeaderProps) {
             <Button
               variant="ghost"
               size="icon"
-              className="rounded-full h-9 w-9 hover:bg-gray-100 dark:hover:bg-gray-800"
+              className="rounded-full h-9 w-9 hover:bg-gray-100 dark:hover:bg-emerald-900/20"
               disabled={loading}
             >
               <Avatar className="h-8 w-8">
@@ -984,7 +984,7 @@ export default function Header({ pageTitle }: HeaderProps) {
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="end"
-            className="w-56 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 shadow-lg"
+            className="w-56 bg-white dark:bg-black/20 dark:backdrop-blur-xl border-gray-200 dark:border-white/10 shadow-lg"
           >
             <DropdownMenuLabel className="text-gray-900 dark:text-white">
               {loading
@@ -993,39 +993,39 @@ export default function Header({ pageTitle }: HeaderProps) {
                   ? `${profile.first_name} ${profile.last_name}`
                   : user?.email || "Hesabım"}
             </DropdownMenuLabel>
-            <DropdownMenuSeparator className="bg-gray-200 dark:bg-gray-700" />
+            <DropdownMenuSeparator className="bg-gray-200 dark:bg-emerald-900/20" />
             <DropdownMenuItem
               onClick={() => router.push("/uygulama/ayarlar")}
-              className="text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700"
+              className="text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20 focus:bg-gray-100 dark:focus:bg-emerald-900/20"
             >
               <UserIcon className="mr-2 h-4 w-4" />
               <span>Profil</span>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => router.push("/uygulama/ayarlar")}
-              className="text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700"
+              className="text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20 focus:bg-gray-100 dark:focus:bg-emerald-900/20"
             >
               <Settings className="mr-2 h-4 w-4" />
               <span>Ayarlar</span>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => router.push("/uygulama/faturalandirma")}
-              className="text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700 cursor-pointer"
+              className="text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20 focus:bg-gray-100 dark:focus:bg-emerald-900/20 cursor-pointer"
             >
               <Briefcase className="mr-2 h-4 w-4" />
               <span>Faturalama</span>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => window.open("https://www.kreditakip.com.tr/sss", "_blank")}
-              className="text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700 cursor-pointer"
+              className="text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20 focus:bg-gray-100 dark:focus:bg-emerald-900/20 cursor-pointer"
             >
               <HelpCircle className="mr-2 h-4 w-4" />
               <span>Destek</span>
             </DropdownMenuItem>
-            <DropdownMenuSeparator className="bg-gray-200 dark:bg-gray-700" />
+            <DropdownMenuSeparator className="bg-gray-200 dark:bg-emerald-900/20" />
             <DropdownMenuItem
               onClick={handleSignOut}
-              className="text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700"
+              className="text-gray-700 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-emerald-900/20 focus:bg-gray-100 dark:focus:bg-emerald-900/20"
             >
               <LogOut className="mr-2 h-4 w-4" />
               <span>Çıkış Yap</span>


### PR DESCRIPTION
… consistently

Removed all light gray colors from dark mode across the entire application and replaced them with emerald/teal themed colors to match the SSS page design.

Application Pages (14 files):
- Tab designs: dark:bg-gray-50 → dark:bg-emerald-900/10
- Table backgrounds: Updated to emerald-themed colors
- Card headers: dark:from-gray-800 dark:to-gray-700 → dark:from-emerald-900/20 dark:to-emerald-900/10
- Text colors: dark:text-gray-* → dark:text-white/* opacity variants
- Icons: dark:text-gray-600 → dark:text-white/40
- Ring borders: dark:ring-gray-700 → dark:ring-emerald-900/30
- Hover states: dark:hover:bg-gray-* → dark:hover:bg-white/10 or emerald-900/20
- Progress bars, badges, buttons: All updated to emerald theme

Header Component:
- Background: dark:bg-gray-900/80 → dark:bg-black/20 with backdrop-blur
- Search input: dark:bg-gray-800 → dark:bg-black/10
- Dropdown menus: dark:bg-gray-800 → dark:bg-black/20 with backdrop-blur
- All borders: dark:border-gray-* → dark:border-white/10
- All text: dark:text-gray-* → dark:text-white/* variants
- Hover states: dark:hover:bg-gray-* → dark:hover:bg-emerald-900/20

Sidebar Component:
- Gradient background: dark:from-gray-900 dark:to-gray-950 → dark:from-emerald-950/30 dark:to-emerald-950/50
- Navigation hover: dark:hover:bg-gray-800/50 → dark:hover:bg-emerald-900/20
- All borders: dark:border-gray-800/50 → dark:border-white/10
- All text: dark:text-gray-* → dark:text-white/* variants
- Dropdown: dark:bg-gray-900 → dark:bg-black/20 with backdrop-blur

Result: Zero gray colors in dark mode. Complete emerald/teal theming with glassmorphism aesthetic throughout the application.

Files updated: 16 total (14 pages + header + sidebar)