### PR TITLE
fix: Add logo_url property to banks interface in PDF generators

### DIFF
--- a/lib/utils/early-payment-pdf.ts
+++ b/lib/utils/early-payment-pdf.ts
@@ -21,6 +21,7 @@ interface EarlyPaymentData {
     credit_code?: string
     banks?: {
       name?: string
+      logo_url?: string | null
     } | null
   } | null
   user: {

--- a/lib/utils/payment-plan-pdf.ts
+++ b/lib/utils/payment-plan-pdf.ts
@@ -7,6 +7,7 @@ interface PaymentPlanData {
     credit_code?: string
     banks?: {
       name?: string
+      logo_url?: string | null
     } | null
   } | null
   user: {


### PR DESCRIPTION
- Added logo_url?: string | null to banks interface in early-payment-pdf.ts
- Added logo_url?: string | null to banks interface in payment-plan-pdf.ts
- Fixed TypeScript type errors preventing production build
- Ensures compatibility with database schema where logo_url can be null