### PR TITLE
fix: Add 'as const' to SchemaType.OBJECT in PDF analysis schema

### DIFF
--- a/app/api/analyze-pdf/route.ts
+++ b/app/api/analyze-pdf/route.ts
@@ -9,7 +9,7 @@ export const maxDuration = 60
 // Gemini Structured Output Schema - PDF Kredi Ödeme Planı
 const paymentPlanSchema = {
   description: "Kredi ödeme planı analiz sonucu",
-  type: SchemaType.OBJECT,
+  type: SchemaType.OBJECT as const,
   properties: {
     bankName: { type: SchemaType.STRING as const, description: "Banka adı", nullable: true },
     planName: { type: SchemaType.STRING as const, description: "Kredi türü (İhtiyaç, Konut, Taşıt, Ticari)", nullable: true },
@@ -26,7 +26,7 @@ const paymentPlanSchema = {
       type: SchemaType.ARRAY as const,
       description: "Taksit listesi",
       items: {
-        type: SchemaType.OBJECT,
+        type: SchemaType.OBJECT as const,
         properties: {
           installmentNumber: { type: SchemaType.NUMBER as const, description: "Taksit numarası" },
           amount: { type: SchemaType.NUMBER as const, description: "Taksit tutarı", nullable: true },


### PR DESCRIPTION
Fixed TypeScript compilation error in PDF analysis that was missing from previous commits. Added 'as const' to both main object and nested installments object type declarations.

Changes:
- Main schema: type: SchemaType.OBJECT → type: SchemaType.OBJECT as const
- Nested items: type: SchemaType.OBJECT → type: SchemaType.OBJECT as const

This brings PDF analysis schema in line with risk analysis schema fixes.

Error fixed:
Type 'SchemaType' is not assignable to type 'SchemaType.OBJECT'