### PR TITLE
fix: Switch risk analysis from gemini-3-pro-preview to gemini-1.5-flash

### DIFF
--- a/app/api/risk-analysis/route.ts
+++ b/app/api/risk-analysis/route.ts
@@ -392,7 +392,7 @@ function createFallbackAnalysis(financialProfile: FinancialProfile, credits: any
 
 async function analyzeRiskWithGemini(financialProfile: FinancialProfile, credits: any[]): Promise<any> {
   const model = genAI.getGenerativeModel({
-    model: "gemini-3-pro-preview",
+    model: "gemini-1.5-flash",
     generationConfig: {
       temperature: 0.2,
       responseMimeType: "application/json",


### PR DESCRIPTION
Changed model to fix 504 timeout and JSON parse errors. Gemini 3 Pro Preview is experimental, slow, and has issues with Structured Output.

Issue:
- 504 Gateway Timeout errors
- "Unexpected token 'A', "An error o"... is not valid JSON"
- Response taking too long (>60s)

Solution:
- Use stable gemini-1.5-flash model
- Faster response times (<10s)
- Better Structured Output support
- Higher quota (15 req/min vs 2 req/min)

Model change:
gemini-3-pro-preview → gemini-1.5-flash