### PR TITLE
fix: update GitHub Actions workflow to use pnpm instead of npm

### DIFF
--- a/.github/workflows/create-app-notifications.yml
+++ b/.github/workflows/create-app-notifications.yml
@@ -20,9 +20,28 @@ jobs:
       with:
         node-version: '18'
 
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 8
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
     - name: Install dependencies
       run: |
-        npm install @supabase/supabase-js mailersend
+        pnpm install --frozen-lockfile
 
     - name: Create App Notifications
       env:


### PR DESCRIPTION
This fixes the EBADPLATFORM error that occurred when npm tried to install platform-specific packages (like @next/swc-darwin-x64) on Linux runners.

Changes:
- Replace npm with pnpm to match the project's package manager
- Add pnpm setup with version 8
- Add pnpm store caching for faster builds
- Use --frozen-lockfile to ensure consistent dependency versions